### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
## What

Add .gitattributes

## Why

In case there would be someone using Windows to avoid potential problems.
I see that even VS Code repo has `.gitattributes`: https://github.com/microsoft/vscode/blob/main/.gitattributes
This .gitattributes is taken from https://code.visualstudio.com/docs/remote/troubleshooting#_resolving-git-line-ending-issues-in-wsl-resulting-in-many-modified-files