### PR TITLE
Add splunkhttp.NewHandler

### DIFF
--- a/instrumentation/net/http/splunkhttp/README.md
+++ b/instrumentation/net/http/splunkhttp/README.md
@@ -1,12 +1,6 @@
 # Splunk specific instrumentation for `net/http`
 
-## Features
-
-### Trace linkage between the APM and RUM products
-
-`ServerTimingMiddleware` wraps the passed handler, functioning like middleware.
-It adds trace context in [traceparent form](https://www.w3.org/TR/trace-context/#traceparent-header)
-as [Server-Timing header](https://www.w3.org/TR/server-timing/) to the HTTP response.
+## Example
 
 Simplified example:
 
@@ -28,9 +22,24 @@ func main() {
 	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Hello"))
 	})
-	handler = splunkhttp.ServerTimingMiddleware(handler)
-	handler = otelhttp.NewHandler(handler, "my-service")
+	handler = splunkhttp.NewHandler(handler, "my-service")
 
 	http.ListenAndServe(":9090", handler)
 }
 ```
+
+## Configuration
+
+### Splunk distribution configuration
+
+| Code                                         | Environment variable                   | Default value  | Purpose                                         |
+| -------------------------------------------- | -------------------------------------- | -------------- | ----------------------------------------------- |
+| `WithServerTiming`, `ServerTimingMiddleware` | `SPLUNK_CONTEXT_SERVER_TIMING_ENABLED` | `true`         | Adds `Server-Timing` header to HTTP responses.  |
+
+## Features
+
+### Trace linkage between the APM and RUM products
+
+`ServerTimingMiddleware` wraps the passed handler, functioning like middleware.
+It adds trace context in [traceparent form](https://www.w3.org/TR/trace-context/#traceparent-header)
+as [Server-Timing header](https://www.w3.org/TR/server-timing/) to the HTTP response.

--- a/instrumentation/net/http/splunkhttp/config.go
+++ b/instrumentation/net/http/splunkhttp/config.go
@@ -34,6 +34,11 @@ func WithOTelOpts(opts ...otelhttp.Option) Option {
 }
 
 // WithServerTiming enables or disables the ServerTimingMiddleware.
+//
+// The default is to enable the ServerTimingMiddleware if this option is not passed.
+// Additionally, the SPLUNK_CONTEXT_SERVER_TIMING_ENABLED environment variable
+// can be set to TRUE or FALSE to specify this option. This option value will be
+// given precedence if both it and the environment variable are set.
 func WithServerTiming(v bool) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.ServerTimingEnabled = v

--- a/instrumentation/net/http/splunkhttp/config.go
+++ b/instrumentation/net/http/splunkhttp/config.go
@@ -1,0 +1,76 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splunkhttp
+
+import (
+	"os"
+	"strings"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+// Environmental variables used for configuration.
+const (
+	EnvVarServerTimingEnabled = "SPLUNK_CONTEXT_SERVER_TIMING_ENABLED" // Adds `Server-Timing` header to HTTP responses
+)
+
+// WithOTelOpts is use to pass the OpenTelemetry SDK options.
+func WithOTelOpts(opts ...otelhttp.Option) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.OTelOpts = opts
+	})
+}
+
+// WithServerTiming enabled or disabled the ServerTimingMiddleware.
+func WithServerTiming(v bool) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.ServerTimingEnabled = v
+	})
+}
+
+// Option is used for setting *optional* config properties.
+type Option interface {
+	apply(*config)
+}
+
+// config represents the available configuration options.
+type config struct {
+	OTelOpts            []otelhttp.Option
+	ServerTimingEnabled bool
+}
+
+// optionFunc provides a convenience wrapper for simple Options
+// that can be represented as functions.
+type optionFunc func(*config)
+
+func (o optionFunc) apply(c *config) {
+	o(c)
+}
+
+// newConfig creates a new config struct and applies opts to it.
+func newConfig(opts ...Option) *config {
+	serverTimingEnabled := true
+	if v := os.Getenv(EnvVarServerTimingEnabled); strings.EqualFold(v, "false") {
+		serverTimingEnabled = false
+	}
+
+	c := &config{
+		ServerTimingEnabled: serverTimingEnabled,
+	}
+	for _, opt := range opts {
+		opt.apply(c)
+	}
+	return c
+}

--- a/instrumentation/net/http/splunkhttp/config.go
+++ b/instrumentation/net/http/splunkhttp/config.go
@@ -23,7 +23,7 @@ import (
 
 // Environmental variables used for configuration.
 const (
-	EnvVarServerTimingEnabled = "SPLUNK_CONTEXT_SERVER_TIMING_ENABLED" // Adds `Server-Timing` header to HTTP responses
+	envVarServerTimingEnabled = "SPLUNK_CONTEXT_SERVER_TIMING_ENABLED" // Adds `Server-Timing` header to HTTP responses
 )
 
 // WithOTelOpts is use to pass the OpenTelemetry SDK options.
@@ -33,14 +33,14 @@ func WithOTelOpts(opts ...otelhttp.Option) Option {
 	})
 }
 
-// WithServerTiming enabled or disabled the ServerTimingMiddleware.
+// WithServerTiming enables or disables the ServerTimingMiddleware.
 func WithServerTiming(v bool) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.ServerTimingEnabled = v
 	})
 }
 
-// Option is used for setting *optional* config properties.
+// Option is used for setting optional config properties.
 type Option interface {
 	apply(*config)
 }
@@ -62,7 +62,7 @@ func (o optionFunc) apply(c *config) {
 // newConfig creates a new config struct and applies opts to it.
 func newConfig(opts ...Option) *config {
 	serverTimingEnabled := true
-	if v := os.Getenv(EnvVarServerTimingEnabled); strings.EqualFold(v, "false") {
+	if v := os.Getenv(envVarServerTimingEnabled); strings.EqualFold(v, "false") {
 		serverTimingEnabled = false
 	}
 

--- a/instrumentation/net/http/splunkhttp/config_test.go
+++ b/instrumentation/net/http/splunkhttp/config_test.go
@@ -28,7 +28,7 @@ func TestConfigs(t *testing.T) {
 		envs   map[string]string
 		assert func(t *testing.T, c *config)
 	}{
-		// Defaiult
+		// Default
 		{
 			name: "Default",
 			assert: func(t *testing.T, c *config) {

--- a/instrumentation/net/http/splunkhttp/config_test.go
+++ b/instrumentation/net/http/splunkhttp/config_test.go
@@ -1,0 +1,89 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splunkhttp
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigs(t *testing.T) {
+	tests := []struct {
+		name   string
+		opts   []Option
+		envs   map[string]string
+		assert func(t *testing.T, c *config)
+	}{
+		// Defaiult
+		{
+			name: "Default",
+			assert: func(t *testing.T, c *config) {
+				assert.Nil(t, c.OTelOpts, "should not set any additional OTel options")
+				assert.True(t, c.ServerTimingEnabled, "should enable ServerTiming")
+			},
+		},
+		// ServerTiming
+		{
+			name: "ServerTiming WithServerTiming(false)",
+			opts: []Option{
+				WithServerTiming(false),
+			},
+			assert: func(t *testing.T, c *config) {
+				assert.False(t, c.ServerTimingEnabled, "should disable ServerTiming")
+			},
+		},
+		{
+			name: "ServerTiming SPLUNK_CONTEXT_SERVER_TIMING_ENABLED=False",
+			envs: map[string]string{
+				"SPLUNK_CONTEXT_SERVER_TIMING_ENABLED": "False",
+			},
+			assert: func(t *testing.T, c *config) {
+				assert.False(t, c.ServerTimingEnabled, "should disable ServerTiming")
+			},
+		},
+		{
+			name: "ServerTiming WithServerTiming(true) SPLUNK_CONTEXT_SERVER_TIMING_ENABLED=True",
+			envs: map[string]string{
+				"SPLUNK_CONTEXT_SERVER_TIMING_ENABLED": "False",
+			},
+			opts: []Option{
+				WithServerTiming(true),
+			},
+			assert: func(t *testing.T, c *config) {
+				assert.True(t, c.ServerTimingEnabled, "should enable ServerTiming, because option has higher priority than env var")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			// set env var before the test and bring the old values back after the test
+			for key, val := range tt.envs {
+				if v, ok := os.LookupEnv(key); ok {
+					defer func() { os.Setenv(key, v) }()
+				} else {
+					defer func() { os.Unsetenv(key) }()
+				}
+				os.Setenv(key, val)
+			}
+
+			cfg := newConfig(tt.opts...)
+			tt.assert(t, cfg)
+		})
+	}
+}

--- a/instrumentation/net/http/splunkhttp/example_test.go
+++ b/instrumentation/net/http/splunkhttp/example_test.go
@@ -30,7 +30,7 @@ func ExampleServerTimingMiddleware() {
 	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, "Hello world") //nolint:errcheck
 	})
-	handler = splunkhttp.NewHandler(handler, "server", splunkhttp.WithOtelOpts(otelhttp.WithTracerProvider(oteltest.NewTracerProvider())))
+	handler = splunkhttp.NewHandler(handler, "server", splunkhttp.WithOTelOpts(otelhttp.WithTracerProvider(oteltest.NewTracerProvider())))
 
 	ts := httptest.NewServer(handler)
 	defer ts.Close()

--- a/instrumentation/net/http/splunkhttp/example_test.go
+++ b/instrumentation/net/http/splunkhttp/example_test.go
@@ -30,8 +30,7 @@ func ExampleServerTimingMiddleware() {
 	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, "Hello world") //nolint:errcheck
 	})
-	handler = splunkhttp.ServerTimingMiddleware(handler)
-	handler = otelhttp.NewHandler(handler, "server", otelhttp.WithTracerProvider(oteltest.NewTracerProvider()))
+	handler = splunkhttp.NewHandler(handler, "server", splunkhttp.WithOtelOpts(otelhttp.WithTracerProvider(oteltest.NewTracerProvider())))
 
 	ts := httptest.NewServer(handler)
 	defer ts.Close()

--- a/instrumentation/net/http/splunkhttp/handler.go
+++ b/instrumentation/net/http/splunkhttp/handler.go
@@ -26,8 +26,8 @@ const (
 	EnvVarServerTimingEnabled = "SPLUNK_CONTEXT_SERVER_TIMING_ENABLED"
 )
 
-// NewHandler wraps the passed handler, functioning like Splunk specific http middleware middleware,
-// in a span named after the operation and with any provided Options.
+// NewHandler wraps the passed handler in a span named after the operation and with any provided Options.
+// This will also enable all the Splunk specific defaults for HTTP tracing.
 func NewHandler(handler http.Handler, operation string, opts ...Option) http.Handler {
 	cfg := newConfig(opts...)
 

--- a/instrumentation/net/http/splunkhttp/handler.go
+++ b/instrumentation/net/http/splunkhttp/handler.go
@@ -1,0 +1,89 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splunkhttp
+
+import (
+	"net/http"
+	"os"
+	"strings"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+const (
+	EnvVarServerTimingEnabled = "SPLUNK_CONTEXT_SERVER_TIMING_ENABLED"
+)
+
+// NewHandler wraps the passed handler, functioning like Splunk specific http middleware middleware,
+// in a span named after the operation and with any provided Options.
+func NewHandler(handler http.Handler, operation string, opts ...Option) http.Handler {
+	cfg := newConfig(opts...)
+
+	if cfg.ServerTimingEnabled {
+		handler = ServerTimingMiddleware(handler)
+	}
+
+	handler = otelhttp.NewHandler(handler, "server", cfg.OtelOpts...)
+	return handler
+}
+
+// WithOtelOpts is use to pass the OpenTelemetry SDK options.
+func WithOtelOpts(opts ...otelhttp.Option) Option {
+	return OptionFunc(func(cfg *config) {
+		cfg.OtelOpts = opts
+	})
+}
+
+// WithServerTiming enabled or disabled the ServerTimingMiddleware.
+func WithServerTiming(v bool) Option {
+	return OptionFunc(func(cfg *config) {
+		cfg.ServerTimingEnabled = v
+	})
+}
+
+// Option Interface used for setting *optional* config properties
+type Option interface {
+	Apply(*config)
+}
+
+// config represents the available configuration options.
+type config struct {
+	OtelOpts            []otelhttp.Option
+	ServerTimingEnabled bool
+}
+
+// OptionFunc provides a convenience wrapper for simple Options
+// that can be represented as functions.
+type OptionFunc func(*config)
+
+func (o OptionFunc) Apply(c *config) {
+	o(c)
+}
+
+// newConfig creates a new config struct and applies opts to it.
+func newConfig(opts ...Option) *config {
+	serverTimingEnabled := true
+	if v := os.Getenv(EnvVarServerTimingEnabled); v == "0" || strings.EqualFold(v, "false") {
+		serverTimingEnabled = false
+	}
+
+	c := &config{
+		ServerTimingEnabled: serverTimingEnabled,
+	}
+	for _, opt := range opts {
+		opt.Apply(c)
+	}
+	return c
+}

--- a/instrumentation/net/http/splunkhttp/handler_test.go
+++ b/instrumentation/net/http/splunkhttp/handler_test.go
@@ -1,0 +1,45 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splunkhttp
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/oteltest"
+)
+
+func TestServerTimingMiddleware(t *testing.T) {
+	resp := responseForHandler(func(handler http.Handler) http.Handler { // nolint:bodyclose // Body is not used
+		handler = ServerTimingMiddleware(handler)
+		return otelhttp.NewHandler(handler, "server", otelhttp.WithTracerProvider(oteltest.NewTracerProvider()))
+	})
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "should return OK status code")
+	assert.Contains(t, resp.Header["Access-Control-Expose-Headers"], "Server-Timing", "should set Access-Control-Expose-Headers header")
+	assert.Regexp(t, "^traceparent;desc=\"00-[0-9a-f]{32}-[0-9a-f]{16}-01\"$", resp.Header.Get("Server-Timing"), "should return properly formated Server-Timing header")
+}
+
+func TestNewHandlerDefault(t *testing.T) {
+	resp := responseForHandler(func(handler http.Handler) http.Handler { // nolint:bodyclose // Body is not used
+		return NewHandler(handler, "server", WithOTelOpts(otelhttp.WithTracerProvider(oteltest.NewTracerProvider())))
+	})
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "should return OK status code")
+	assert.Contains(t, resp.Header["Access-Control-Expose-Headers"], "Server-Timing", "should set Access-Control-Expose-Headers header")
+	assert.Regexp(t, "^traceparent;desc=\"00-[0-9a-f]{32}-[0-9a-f]{16}-01\"$", resp.Header.Get("Server-Timing"), "should return properly formated Server-Timing header")
+}

--- a/instrumentation/net/http/splunkhttp/server_timing_test.go
+++ b/instrumentation/net/http/splunkhttp/server_timing_test.go
@@ -35,9 +35,9 @@ func TestServerTimingMiddleware(t *testing.T) {
 	assert.Regexp(t, "^traceparent;desc=\"00-[0-9a-f]{32}-[0-9a-f]{16}-01\"$", resp.Header.Get("Server-Timing"), "should return properly formated Server-Timing header")
 }
 
-func TestNewHandler_Default(t *testing.T) {
+func TestNewHandlerDefault(t *testing.T) {
 	resp := responseForHandler(func(handler http.Handler) http.Handler { // nolint:bodyclose // Body is not used
-		return NewHandler(handler, "server", WithOtelOpts(otelhttp.WithTracerProvider(oteltest.NewTracerProvider())))
+		return NewHandler(handler, "server", WithOTelOpts(otelhttp.WithTracerProvider(oteltest.NewTracerProvider())))
 	})
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "should return OK status code")
@@ -45,9 +45,9 @@ func TestNewHandler_Default(t *testing.T) {
 	assert.Regexp(t, "^traceparent;desc=\"00-[0-9a-f]{32}-[0-9a-f]{16}-01\"$", resp.Header.Get("Server-Timing"), "should return properly formated Server-Timing header")
 }
 
-func TestNewHandler_ServerTimingDisabled(t *testing.T) {
+func TestNewHandlerServerTimingDisabled(t *testing.T) {
 	resp := responseForHandler(func(handler http.Handler) http.Handler { // nolint:bodyclose // Body is not used
-		return NewHandler(handler, "server", WithOtelOpts(otelhttp.WithTracerProvider(oteltest.NewTracerProvider())), WithServerTiming(false))
+		return NewHandler(handler, "server", WithOTelOpts(otelhttp.WithTracerProvider(oteltest.NewTracerProvider())), WithServerTiming(false))
 	})
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "should return OK status code")

--- a/instrumentation/net/http/splunkhttp/server_timing_test.go
+++ b/instrumentation/net/http/splunkhttp/server_timing_test.go
@@ -16,34 +16,12 @@ package splunkhttp
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/oteltest"
 )
-
-func TestServerTimingMiddleware(t *testing.T) {
-	resp := responseForHandler(func(handler http.Handler) http.Handler { // nolint:bodyclose // Body is not used
-		handler = ServerTimingMiddleware(handler)
-		return otelhttp.NewHandler(handler, "server", otelhttp.WithTracerProvider(oteltest.NewTracerProvider()))
-	})
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode, "should return OK status code")
-	assert.Contains(t, resp.Header["Access-Control-Expose-Headers"], "Server-Timing", "should set Access-Control-Expose-Headers header")
-	assert.Regexp(t, "^traceparent;desc=\"00-[0-9a-f]{32}-[0-9a-f]{16}-01\"$", resp.Header.Get("Server-Timing"), "should return properly formated Server-Timing header")
-}
-
-func TestNewHandlerDefault(t *testing.T) {
-	resp := responseForHandler(func(handler http.Handler) http.Handler { // nolint:bodyclose // Body is not used
-		return NewHandler(handler, "server", WithOTelOpts(otelhttp.WithTracerProvider(oteltest.NewTracerProvider())))
-	})
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode, "should return OK status code")
-	assert.Contains(t, resp.Header["Access-Control-Expose-Headers"], "Server-Timing", "should set Access-Control-Expose-Headers header")
-	assert.Regexp(t, "^traceparent;desc=\"00-[0-9a-f]{32}-[0-9a-f]{16}-01\"$", resp.Header.Get("Server-Timing"), "should return properly formated Server-Timing header")
-}
 
 func TestNewHandlerServerTimingDisabled(t *testing.T) {
 	resp := responseForHandler(func(handler http.Handler) http.Handler { // nolint:bodyclose // Body is not used
@@ -53,16 +31,4 @@ func TestNewHandlerServerTimingDisabled(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "should return OK status code")
 	assert.NotContains(t, resp.Header["Access-Control-Expose-Headers"], "Server-Timing", "should NOT set Access-Control-Expose-Headers header")
 	assert.NotRegexp(t, "^traceparent;desc=\"00-[0-9a-f]{32}-[0-9a-f]{16}-01\"$", resp.Header.Get("Server-Timing"), "should not add traceID to Server-Timing header")
-}
-
-func responseForHandler(wrapFn func(http.Handler) http.Handler) *http.Response {
-	content := []byte("Any content")
-	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(content) //nolint:errcheck
-	})
-	handler = wrapFn(handler)
-
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, httptest.NewRequest("", "/", nil))
-	return w.Result()
 }


### PR DESCRIPTION
## Why 

https://github.com/signalfx/splunk-otel-go/pull/18#issuecomment-808338996

>If we could add some form of this to the distro package. That would seem to make sense to me given it is supposed to be the super mega deluxe easy path for setup Splunk customers.

## What

- Add `splunkhttp.NewHandler`

## Next

- https://github.com/signalfx/splunk-otel-go/pull/30#discussion_r606000990