### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## [Unreleased]
+
+## [0.1.0] - 2021-04-08
+
 ### Added
 
 - Add [`distro`](./distro) package providing functionality to quickly setup the OpenTelemetry Go implementation with useful Splunk defaults.
 - Add [`splunkhttp`](./instrumentation/net/http/splunkhttp) module providing additional Splunk specific instrumentation for `net/http`.
+
+[Unreleased]: https://github.com/signalfx/splunk-otel-go/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.1.0

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package splunkotel // import "github.com/signalfx/splunk-otel-go"
 
 // Version is the current release version of splunk-otel-go in use.
 func Version() string {
-	return "0.0.0"
+	return "0.1.0"
 }


### PR DESCRIPTION
### Added

- Add [`distro`](./distro) package providing functionality to quickly setup the OpenTelemetry Go implementation with useful Splunk defaults.
- Add [`splunkhttp`](./instrumentation/net/http/splunkhttp) module providing additional Splunk specific instrumentation for `net/http`.