### PR TITLE
Rename ServerTiming to TraceResponseHeader

### DIFF
--- a/instrumentation/net/http/splunkhttp/README.md
+++ b/instrumentation/net/http/splunkhttp/README.md
@@ -32,14 +32,14 @@ func main() {
 
 ### Splunk distribution configuration
 
-| Code                                         | Environment variable                   | Default value  | Purpose                                         |
-| -------------------------------------------- | -------------------------------------- | -------------- | ----------------------------------------------- |
-| `WithServerTiming`, `ServerTimingMiddleware` | `SPLUNK_CONTEXT_SERVER_TIMING_ENABLED` | `true`         | Adds `Server-Timing` header to HTTP responses.  |
+| Code                                                       | Environment variable                   | Default value  | Purpose                                         |
+| ---------------------------------------------------------- | -------------------------------------- | -------------- | ----------------------------------------------- |
+| `WithTraceResponseHeader`, `TraceResponseHeaderMiddleware` | `SPLUNK_TRACE_RESPONSE_HEADER_ENABLED` | `true`         | Adds `Server-Timing` header to HTTP responses.  |
 
 ## Features
 
 ### Trace linkage between the APM and RUM products
 
-`ServerTimingMiddleware` wraps the passed handler, functioning like middleware.
+`TraceResponseHeaderMiddleware` wraps the passed handler, functioning like middleware.
 It adds trace context in [traceparent form](https://www.w3.org/TR/trace-context/#traceparent-header)
 as [Server-Timing header](https://www.w3.org/TR/server-timing/) to the HTTP response.

--- a/instrumentation/net/http/splunkhttp/config.go
+++ b/instrumentation/net/http/splunkhttp/config.go
@@ -23,7 +23,7 @@ import (
 
 // Environmental variables used for configuration.
 const (
-	envVarServerTimingEnabled = "SPLUNK_CONTEXT_SERVER_TIMING_ENABLED" // Adds `Server-Timing` header to HTTP responses
+	envVarTraceResponseHeaderEnabled = "SPLUNK_TRACE_RESPONSE_HEADER_ENABLED" // Adds `Server-Timing` header to HTTP responses
 )
 
 // WithOTelOpts is use to pass the OpenTelemetry SDK options.
@@ -33,15 +33,15 @@ func WithOTelOpts(opts ...otelhttp.Option) Option {
 	})
 }
 
-// WithServerTiming enables or disables the ServerTimingMiddleware.
+// WithTraceResponseHeader enables or disables the TraceResponseHeaderMiddleware.
 //
-// The default is to enable the ServerTimingMiddleware if this option is not passed.
-// Additionally, the SPLUNK_CONTEXT_SERVER_TIMING_ENABLED environment variable
+// The default is to enable the TraceResponseHeaderMiddleware if this option is not passed.
+// Additionally, the SPLUNK_TRACE_RESPONSE_HEADER_ENABLED environment variable
 // can be set to TRUE or FALSE to specify this option. This option value will be
 // given precedence if both it and the environment variable are set.
-func WithServerTiming(v bool) Option {
+func WithTraceResponseHeader(v bool) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.ServerTimingEnabled = v
+		cfg.TraceResponseHeaderEnabled = v
 	})
 }
 
@@ -52,8 +52,8 @@ type Option interface {
 
 // config represents the available configuration options.
 type config struct {
-	OTelOpts            []otelhttp.Option
-	ServerTimingEnabled bool
+	OTelOpts                   []otelhttp.Option
+	TraceResponseHeaderEnabled bool
 }
 
 // optionFunc provides a convenience wrapper for simple Options
@@ -66,13 +66,13 @@ func (o optionFunc) apply(c *config) {
 
 // newConfig creates a new config struct and applies opts to it.
 func newConfig(opts ...Option) *config {
-	serverTimingEnabled := true
-	if v := os.Getenv(envVarServerTimingEnabled); strings.EqualFold(v, "false") {
-		serverTimingEnabled = false
+	traceResponseHeaderEnabled := true
+	if v := os.Getenv(envVarTraceResponseHeaderEnabled); strings.EqualFold(v, "false") {
+		traceResponseHeaderEnabled = false
 	}
 
 	c := &config{
-		ServerTimingEnabled: serverTimingEnabled,
+		TraceResponseHeaderEnabled: traceResponseHeaderEnabled,
 	}
 	for _, opt := range opts {
 		opt.apply(c)

--- a/instrumentation/net/http/splunkhttp/config_test.go
+++ b/instrumentation/net/http/splunkhttp/config_test.go
@@ -33,38 +33,38 @@ func TestConfigs(t *testing.T) {
 			name: "Default",
 			assert: func(t *testing.T, c *config) {
 				assert.Nil(t, c.OTelOpts, "should not set any additional OTel options")
-				assert.True(t, c.ServerTimingEnabled, "should enable ServerTiming")
+				assert.True(t, c.TraceResponseHeaderEnabled, "should enable TraceResponseHeader")
 			},
 		},
-		// ServerTiming
+		// TraceResponseHeader
 		{
-			name: "ServerTiming WithServerTiming(false)",
+			name: "TraceResponseHeader WithTraceResponseHeader(false)",
 			opts: []Option{
-				WithServerTiming(false),
+				WithTraceResponseHeader(false),
 			},
 			assert: func(t *testing.T, c *config) {
-				assert.False(t, c.ServerTimingEnabled, "should disable ServerTiming")
+				assert.False(t, c.TraceResponseHeaderEnabled, "should disable TraceResponseHeader")
 			},
 		},
 		{
-			name: "ServerTiming SPLUNK_CONTEXT_SERVER_TIMING_ENABLED=False",
+			name: "TraceResponseHeader SPLUNK_TRACE_RESPONSE_HEADER_ENABLED=False",
 			envs: map[string]string{
-				"SPLUNK_CONTEXT_SERVER_TIMING_ENABLED": "False",
+				"SPLUNK_TRACE_RESPONSE_HEADER_ENABLED": "False",
 			},
 			assert: func(t *testing.T, c *config) {
-				assert.False(t, c.ServerTimingEnabled, "should disable ServerTiming")
+				assert.False(t, c.TraceResponseHeaderEnabled, "should disable TraceResponseHeader")
 			},
 		},
 		{
-			name: "ServerTiming WithServerTiming(true) SPLUNK_CONTEXT_SERVER_TIMING_ENABLED=True",
+			name: "TraceResponseHeader WithTraceResponseHeader(true) SPLUNK_TRACE_RESPONSE_HEADER_ENABLED=True",
 			envs: map[string]string{
-				"SPLUNK_CONTEXT_SERVER_TIMING_ENABLED": "False",
+				"SPLUNK_TRACE_RESPONSE_HEADER_ENABLED": "False",
 			},
 			opts: []Option{
-				WithServerTiming(true),
+				WithTraceResponseHeader(true),
 			},
 			assert: func(t *testing.T, c *config) {
-				assert.True(t, c.ServerTimingEnabled, "should enable ServerTiming, because option has higher priority than env var")
+				assert.True(t, c.TraceResponseHeaderEnabled, "should enable TraceResponseHeader, because option has higher priority than env var")
 			},
 		},
 	}

--- a/instrumentation/net/http/splunkhttp/example_test.go
+++ b/instrumentation/net/http/splunkhttp/example_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp"
 )
 
-func ExampleServerTimingMiddleware() {
+func ExampleTraceResponseHeaderMiddleware() {
 	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, "Hello world") //nolint:errcheck
 	})

--- a/instrumentation/net/http/splunkhttp/handler.go
+++ b/instrumentation/net/http/splunkhttp/handler.go
@@ -24,8 +24,8 @@ import (
 // This will also enable all the Splunk specific defaults for HTTP tracing.
 func NewHandler(handler http.Handler, operation string, opts ...Option) http.Handler {
 	cfg := newConfig(opts...)
-	if cfg.ServerTimingEnabled {
-		handler = ServerTimingMiddleware(handler)
+	if cfg.TraceResponseHeaderEnabled {
+		handler = TraceResponseHeaderMiddleware(handler)
 	}
 	handler = otelhttp.NewHandler(handler, operation, cfg.OTelOpts...)
 	return handler

--- a/instrumentation/net/http/splunkhttp/handler_test.go
+++ b/instrumentation/net/http/splunkhttp/handler_test.go
@@ -23,9 +23,9 @@ import (
 	"go.opentelemetry.io/otel/oteltest"
 )
 
-func TestServerTimingMiddleware(t *testing.T) {
+func TestTraceResponseHeaderMiddleware(t *testing.T) {
 	resp := responseForHandler(func(handler http.Handler) http.Handler { // nolint:bodyclose // Body is not used
-		handler = ServerTimingMiddleware(handler)
+		handler = TraceResponseHeaderMiddleware(handler)
 		return otelhttp.NewHandler(handler, "server", otelhttp.WithTracerProvider(oteltest.NewTracerProvider()))
 	})
 

--- a/instrumentation/net/http/splunkhttp/server_timing.go
+++ b/instrumentation/net/http/splunkhttp/server_timing.go
@@ -21,11 +21,11 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// ServerTimingMiddleware wraps the passed handler, functioning like middleware.
+// TraceResponseHeaderMiddleware wraps the passed handler, functioning like middleware.
 // It adds trace context in traceparent form (https://www.w3.org/TR/trace-context/#traceparent-header)
 // as Server-Timing header (https://www.w3.org/TR/server-timing/)
 // to the HTTP response.
-func ServerTimingMiddleware(handler http.Handler) http.Handler {
+func TraceResponseHeaderMiddleware(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if spanCtx := trace.SpanContextFromContext(r.Context()); spanCtx.IsValid() {
 			w.Header().Add("Access-Control-Expose-Headers", "Server-Timing")

--- a/instrumentation/net/http/splunkhttp/server_timing_test.go
+++ b/instrumentation/net/http/splunkhttp/server_timing_test.go
@@ -23,9 +23,9 @@ import (
 	"go.opentelemetry.io/otel/oteltest"
 )
 
-func TestNewHandlerServerTimingDisabled(t *testing.T) {
+func TestNewHandlerTraceResponseHeaderDisabled(t *testing.T) {
 	resp := responseForHandler(func(handler http.Handler) http.Handler { // nolint:bodyclose // Body is not used
-		return NewHandler(handler, "server", WithOTelOpts(otelhttp.WithTracerProvider(oteltest.NewTracerProvider())), WithServerTiming(false))
+		return NewHandler(handler, "server", WithOTelOpts(otelhttp.WithTracerProvider(oteltest.NewTracerProvider())), WithTraceResponseHeader(false))
 	})
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "should return OK status code")


### PR DESCRIPTION
## Why

Per https://github.com/signalfx/gdi-specification/pull/32

## What

- Rename `SPLUNK_SERVER_TIMING_CONTEXT` environmental variable to `SPLUNK_TRACE_RESPONSE_HEADER_ENABLED` together with all related variables, functions etc.