### PR TITLE
Prepare release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,8 @@ Now the `BatchSpanProcessor` that `distro` configures by default will not experi
 - Add [`distro`](./distro) package providing functionality to quickly setup the OpenTelemetry Go implementation with useful Splunk defaults.
 - Add [`splunkhttp`](./instrumentation/net/http/splunkhttp) module providing additional Splunk specific instrumentation for `net/http`.
 
-[Unreleased]: https://github.com/signalfx/splunk-otel-go/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/signalfx/splunk-otel-go/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.4.0
 [0.3.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.3.0
 [0.2.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.2.0
 [0.1.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [0.4.0] - 2021-06-30
 
-The primary change of this release is updating the dependency of `go.opentelemetry.io/otel*` packages from [`v0.20.0`][otel-v0.20.0] to [`v1.0.0-RC1`][otel-v1.0.0-RC1] and `go.opentelemetry.io/contrib*` packages from [`v0.19.0`][contrib-v0.19.0] to [`v0.20.0`][contrib-v0.20.0].
+The primary change of this release is updating the dependency of `go.opentelemetry.io/otel*` packages from [`v0.20.0`][otel-v0.20.0] to [`v1.0.0-RC1`][otel-v1.0.0-RC1] and `go.opentelemetry.io/contrib*` packages from [`v0.20.0`][contrib-v0.20.0] to [`v0.21.0`][contrib-v0.21.0].
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.4.0] - 2021-05-18
+
+The primary change of this release is updating the dependency of `go.opentelemetry.io/otel*` packages from [`v0.20.0`][otel-v0.20.0] to [`v1.0.0-RC1`][otel-v1.0.0-RC1] and `go.opentelemetry.io/contrib*` packages from [`v0.19.0`][contrib-v0.19.0] to [`v0.20.0`][contrib-v0.20.0].
+
 ### Changed
 
 - Update `go.opentelemetry.io/otel*` dependencies from [`v0.20.0`][otel-v0.20.0] to [`v1.0.0-RC1`][otel-v1.0.0-RC1].
@@ -43,7 +47,7 @@ for sending data directly to Splunk Observability Cloud.
 
 ## [0.2.0] - 2021-04-27
 
-The primary change of this release is updating the dependency of `go.opentelemetry.io/otel*` packages from [`v0.19.0`][otel-v0.19.0] to [`v0.20.0`][otel-v0.20.0] and similarly `go.opentelemetry.io/contrib*` package from [`v0.19.0`][contrib-v0.19.0] to [`v0.20.0`][contrib-v0.20.0].
+The primary change of this release is updating the dependency of `go.opentelemetry.io/otel*` packages from [`v0.19.0`][otel-v0.19.0] to [`v0.20.0`][otel-v0.20.0] and similarly `go.opentelemetry.io/contrib*` packages from [`v0.19.0`][contrib-v0.19.0] to [`v0.20.0`][contrib-v0.20.0].
 This includes [a fix](https://github.com/open-telemetry/opentelemetry-go/pull/1830) in the Jaeger exporter.
 This fix removes the duplicate batching that the exporter implemented.
 Now the `BatchSpanProcessor` that `distro` configures by default will not experience an impedance mismatch with this duplicate batching.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-## [0.4.0] - 2021-05-18
+## [0.4.0] - 2021-06-30
 
 The primary change of this release is updating the dependency of `go.opentelemetry.io/otel*` packages from [`v0.20.0`][otel-v0.20.0] to [`v1.0.0-RC1`][otel-v1.0.0-RC1] and `go.opentelemetry.io/contrib*` packages from [`v0.19.0`][contrib-v0.19.0] to [`v0.20.0`][contrib-v0.20.0].
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+SHELL := /bin/bash
+
 GO               = go
 TIMEOUT          = 15
 PKGS             = ./...

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This Splunk distribution comes with the following defaults:
   exporter](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/jaeger)
   configured to send spans to a locally running Splunk OpenTelemetry Connector](https://github.com/signalfx/splunk-otel-collector)
   (`http://localhost:14268/api/traces`).
-- Unlimited default limits for [configuration options](#trace-configuration) to
+- Unlimited default limits for configuration options to
   support full-fidelity traces.
 
 > :construction: This project is currently in **BETA**. It is **officially supported** by Splunk. However, breaking changes **MAY** be introduced.

--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@ application to capture and report distributed traces to Splunk APM.
 This Splunk distribution comes with the following defaults:
 
 - [B3 context propagation](https://github.com/openzipkin/b3-propagation).
-- [Jaeger thrift
-  exporter](https://opentelemetry-python.readthedocs.io/en/stable/exporter/jaeger/jaeger.html)
-  configured to send spans to a locally running [SignalFx Smart
-  Agent](https://docs.signalfx.com/en/latest/apm/apm-getting-started/apm-smart-agent.html)
-  (`http://localhost:9080/v1/trace`).
+- [Jaeger Thrift over HTTP
+  exporter](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/jaeger)
+  configured to send spans to a locally running Splunk OpenTelemetry Connector](https://github.com/signalfx/splunk-otel-collector)
+  (`http://localhost:14268/api/traces`).
 - Unlimited default limits for [configuration options](#trace-configuration) to
   support full-fidelity traces.
 
@@ -27,23 +26,25 @@ This Splunk distribution comes with the following defaults:
 
 ## Getting Started
 
-Supported libraries are listed
-[here](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation).
+### Bootstrapping
 
-To ensure OpenTelemetry is correctly configured to participate in traces and send telemetry to Splunk, use the [`distro`](./distro) package.
+Configure OpenTelemetry using the [`distro`](./distro) package:
 
-```golang
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/signalfx/splunk-otel-go/distro"
+)
+
 func main() {
-	// By default, the Run function will create a Jaeger exporter to a locally
-	// running Splunk Smart Agent at http://localhost:9080 and will configure
-	// the B3 context propagation format to be used in extracting and
-	// injecting trace context.
 	sdk, err := distro.Run()
 	if err != nil {
 		panic(err)
 	}
-	// To ensure all spans are flushed before the application exits, make sure
-	// to shutdown.
+	// Ensure all spans are flushed before the application exits.
 	defer func() {
 		if err := sdk.Shutdown(context.Background()); err != nil {
 			panic(err)
@@ -53,7 +54,16 @@ func main() {
     /* ... */
 ```
 
-## Manually instrument an application
+### Library instrumentation
+
+Supported libraries are listed
+[here](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation).
+
+Splunk specific instrumentations:
+
+- [`splunkhttp`](./instrumentation/net/http/splunkhttp)
+
+### Manual instrumentation
 
 Documentation on how to manually instrument a Go application is available
 [here](https://opentelemetry.io/docs/go/getting-started/).
@@ -66,12 +76,8 @@ Documentation on how to manually instrument a Go application is available
 
 [<a name="cfg1">1</a>]: The [Splunk's organization access token](https://docs.splunk.com/observability/admin/authentication-tokens/org-tokens.html)
 allows exporters sending data directly to the [Splunk Observability Cloud](https://dev.splunk.com/observability/docs/apibasics/api_list/).
-To do so, the `OTEL_EXPORTER_JAEGER_ENDPOINT` or `contrib.WithEndpoint` must be set
+To do so, the `OTEL_EXPORTER_JAEGER_ENDPOINT` or `distro.WithEndpoint` must be passed to `distro.Run`
 with Splunk back-end ingest endpoint URL: `https://ingest.<REALM>.signalfx.com/v2/trace`.
-
-## Splunk specific instrumentations
-
-- [`splunkhttp`](./instrumentation/net/http/splunkhttp)
 
 ## License and versioning
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,23 +4,15 @@
 
 Update go.mod for submodules to depend on the new release which will happen in the next step.
 
-1. Update [CHANGELOG.md](CHANGELOG.md) with new the new release.
-
-2. Run the pre-release script. It creates a branch `pre_release_<new tag>` that will contain all release changes.
+1. Run the pre-release script. It creates a branch `pre_release_<new tag>` that will contain all release changes.
 
     ```sh
     ./pre_release.sh -t <new tag>
     ```
 
-3. Verify the changes.
+2. Update [CHANGELOG.md](CHANGELOG.md) with new the new release.
 
-    ```sh
-    git diff
-    ```
-
-    This should have changed the version for all modules to be `<new tag>`.
-
-4. Push the changes to upstream and create a Pull Request on GitHub.
+3. Push the changes to upstream and create a Pull Request on GitHub.
 
 ## Tag
 

--- a/distro/example_test.go
+++ b/distro/example_test.go
@@ -21,10 +21,9 @@ import (
 )
 
 func Example() {
-	// By default, the Run function will create a Jaeger exporter to a locally
-	// running Splunk Smart Agent at http://localhost:9080 and will configure
-	// the B3 context propagation format to be used in extracting and
-	// injecting trace context.
+	// By default, the Run function creates a Jaeger Thrift over HTTP exporter
+	// to http://localhost:14268/api/traces and configures the B3 context
+	// propagation format to be used in extracting and injecting trace context.
 	sdk, err := distro.Run()
 	if err != nil {
 		panic(err)

--- a/distro/otel.go
+++ b/distro/otel.go
@@ -16,10 +16,9 @@
 Package distro provides functionality to quickly setup the OpenTelemetry Go
 implementation with useful Splunk defaults.
 
-The default configuration will correctly set the default OpenTelemetry SDK to
-propagate traces and export all spans to a locally running Splunk Smart Agent.
-Information about the Splunk Smart Agent can be found here
-https://docs.signalfx.com/en/latest/apm/apm-getting-started/apm-smart-agent.html
+The default configuration sets the default OpenTelemetry SDK to propagate traces
+using B3 propagator and export all spans to a locally running
+Splunk OpenTelemetry Connector (http://localhost:14268/api/traces).
 */
 package distro
 

--- a/version.go
+++ b/version.go
@@ -20,5 +20,5 @@ package splunkotel // import "github.com/signalfx/splunk-otel-go"
 
 // Version is the current release version of splunk-otel-go in use.
 func Version() string {
-	return "0.3.0"
+	return "0.4.0"
 }


### PR DESCRIPTION
## Why

Have a RC-compatible release.

## What

- Prepare release
- Update docs and examples

## Changelog

The primary change of this release is updating the dependency of `go.opentelemetry.io/otel*` packages from [`v0.20.0`][otel-v0.20.0] to [`v1.0.0-RC1`][otel-v1.0.0-RC1] and `go.opentelemetry.io/contrib*` packages from [`v0.20.0`][contrib-v0.20.0] to [`v0.21.0`][contrib-v0.21.0].

### Changed

- Update `go.opentelemetry.io/otel*` dependencies from [`v0.20.0`][otel-v0.20.0] to [`v1.0.0-RC1`][otel-v1.0.0-RC1].
- Update `go.opentelemetry.io/contrib*` dependencies from [`v0.20.0`][contrib-v0.20.0] to [`v0.21.0`][contrib-v0.21.0].

### Remove

- Drop support for Go 1.14 as [`go.opentelemetry.io@v1.0.0-RC1`](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.0.0-RC1) did the same.

[otel-v1.0.0-RC1]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.0.0-RC1
[otel-v0.20.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.20.0


[contrib-v0.21.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.21.0
[contrib-v0.20.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.20.0