### PR TITLE
Improve docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         go-version: [1.16, 1.15]
         os: [ubuntu-latest, macos-latest, windows-latest]
         # GitHub Actions does not support arm* architectures on default
-        # runners. It is possible to acomplish this with a self-hosted runner
+        # runners. It is possible to accomplish this with a self-hosted runner
         # if we want to add this in the future:
         # https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow
         arch: ["386", amd64]

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,12 @@
+# Default state for all rules
+default: true
+
+# hard-tabs
+MD010: false
+
+# no-duplicate-header
+MD024:
+  siblings_only: true
+
+# inline-HTML
+MD033: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [0.4.0] - 2021-06-30
 
-The primary change of this release is updating the dependency of `go.opentelemetry.io/otel*` packages from [`v0.20.0`][otel-v0.20.0] to [`v1.0.0-RC1`][otel-v1.0.0-RC1] and `go.opentelemetry.io/contrib*` packages from [`v0.20.0`][contrib-v0.20.0] to [`v0.21.0`][contrib-v0.21.0].
+The primary change of this release is updating the dependency of `go.opentelemetry.io/otel*`
+packages from [`v0.20.0`][otel-v0.20.0] to [`v1.0.0-RC1`][otel-v1.0.0-RC1] and
+`go.opentelemetry.io/contrib*` packages from [`v0.20.0`][contrib-v0.20.0] to [`v0.21.0`][contrib-v0.21.0].
 
 ### Changed
 
-- Update `go.opentelemetry.io/otel*` dependencies from [`v0.20.0`][otel-v0.20.0] to [`v1.0.0-RC1`][otel-v1.0.0-RC1].
-- Update `go.opentelemetry.io/contrib*` dependencies from [`v0.20.0`][contrib-v0.20.0] to [`v0.21.0`][contrib-v0.21.0].
+- Update `go.opentelemetry.io/otel*` dependencies from [`v0.20.0`][otel-v0.20.0]
+  to [`v1.0.0-RC1`][otel-v1.0.0-RC1].
+- Update `go.opentelemetry.io/contrib*` dependencies from [`v0.20.0`][contrib-v0.20.0]
+  to [`v0.21.0`][contrib-v0.21.0].
 
 ### Remove
 
-- Drop support for Go 1.14 as [`go.opentelemetry.io@v1.0.0-RC1`](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.0.0-RC1) did the same.
+- Drop support for Go 1.14 as [`go.opentelemetry.io@v1.0.0-RC1`](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.0.0-RC1)
+  did the same.
 
 ## [0.3.0] - 2021-05-18
 
@@ -29,10 +34,10 @@ for sending data directly to Splunk Observability Cloud.
 ### Added
 
 - Add support for setting the [Splunk's organization access token](https://docs.splunk.com/observability/admin/authentication-tokens/org-tokens.html)
-  using the `SPLUNK_ACCESS_TOKEN` environmental variable or `distro.WithAccessToken` option.
-  It allows exporters sending data directly to the Splunk Observability Cloud.
-  To do so, the `OTEL_EXPORTER_JAEGER_ENDPOINT` or `distro.WithEndpoint` must be set
-  with Splunk back-end ingest endpoint URL: `https://ingest.<REALM>.signalfx.com/v2/trace`.
+  using the `SPLUNK_ACCESS_TOKEN` environmental variable or `distro.WithAccessToken`
+  option. It allows exporters sending data directly to the Splunk Observability Cloud.
+  To do so, the `OTEL_EXPORTER_JAEGER_ENDPOINT` or `distro.WithEndpoint` must be
+  set with Splunk back-end ingest endpoint URL: `https://ingest.<REALM>.signalfx.com/v2/trace`.
 
 ### Changed
 
@@ -43,26 +48,35 @@ for sending data directly to Splunk Observability Cloud.
 
 ### Removed
 
-- Remove `SIGNALFX_ENDPOINT_URL` environmental variable, use `OTEL_EXPORTER_JAEGER_ENDPOINT` instead.
+- Remove `SIGNALFX_ENDPOINT_URL` environmental variable, use `OTEL_EXPORTER_JAEGER_ENDPOINT`
+  instead.
 
 ## [0.2.0] - 2021-04-27
 
-The primary change of this release is updating the dependency of `go.opentelemetry.io/otel*` packages from [`v0.19.0`][otel-v0.19.0] to [`v0.20.0`][otel-v0.20.0] and similarly `go.opentelemetry.io/contrib*` packages from [`v0.19.0`][contrib-v0.19.0] to [`v0.20.0`][contrib-v0.20.0].
-This includes [a fix](https://github.com/open-telemetry/opentelemetry-go/pull/1830) in the Jaeger exporter.
+The primary change of this release is updating the dependency of `go.opentelemetry.io/otel*`
+packages from [`v0.19.0`][otel-v0.19.0] to [`v0.20.0`][otel-v0.20.0] and similarly
+`go.opentelemetry.io/contrib*` packages from [`v0.19.0`][contrib-v0.19.0] to [`v0.20.0`][contrib-v0.20.0].
+This includes [a fix](https://github.com/open-telemetry/opentelemetry-go/pull/1830)
+in the Jaeger exporter.
 This fix removes the duplicate batching that the exporter implemented.
-Now the `BatchSpanProcessor` that `distro` configures by default will not experience an impedance mismatch with this duplicate batching.
+Now the `BatchSpanProcessor` that `distro` configures by default will not experience
+an impedance mismatch with this duplicate batching.
 
 ### Changed
 
-- Update `go.opentelemetry.io/otel*` dependencies from [`v0.19.0`][otel-v0.19.0] to [`v0.20.0`][otel-v0.20.0].
-- Update `go.opentelemetry.io/contrib*` dependencies from [`v0.19.0`][contrib-v0.19.0] to [`v0.20.0`][contrib-v0.20.0].
+- Update `go.opentelemetry.io/otel*` dependencies from [`v0.19.0`][otel-v0.19.0]
+  to [`v0.20.0`][otel-v0.20.0].
+- Update `go.opentelemetry.io/contrib*` dependencies from [`v0.19.0`][contrib-v0.19.0]
+  to [`v0.20.0`][contrib-v0.20.0].
 
 ## [0.1.0] - 2021-04-08
 
 ### Added
 
-- Add [`distro`](./distro) package providing functionality to quickly setup the OpenTelemetry Go implementation with useful Splunk defaults.
-- Add [`splunkhttp`](./instrumentation/net/http/splunkhttp) module providing additional Splunk specific instrumentation for `net/http`.
+- Add [`distro`](./distro) package providing functionality to quickly setup
+  the OpenTelemetry Go implementation with useful Splunk defaults.
+- Add [`splunkhttp`](./instrumentation/net/http/splunkhttp) module providing
+  additional Splunk specific instrumentation for `net/http`.
 
 [Unreleased]: https://github.com/signalfx/splunk-otel-go/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.4.0

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ SUBMODULES = $(filter-out ., $(ALL_GO_MOD_DIRS))
 all: mod-tidy build lint license-check test-race
 
 .PHONY: ci
-ci: mod-tidy build lint license-check diff
+ci: mod-tidy build lint markdownlint license-check diff
 
 .PHONY: build
 build: # build whole codebase
@@ -82,6 +82,10 @@ test-coverage:
 lint: | $(GOLANGCI_LINT)
 # Run once to fix and run again to verify resolution.
 	${call for-all-modules,$(GOLANGCI_LINT) run --fix && $(GOLANGCI_LINT) run}
+
+.PHONY: markdownlint
+markdownlint:
+	docker run --rm -v $(PWD):/markdown 06kellyjac/markdownlint-cli:0.27.1 **/*.md
 
 # Pre-release targets
 

--- a/README.md
+++ b/README.md
@@ -146,9 +146,12 @@ with Splunk back-end ingest endpoint URL: `https://ingest.<REALM>.signalfx.com/v
 
 ### Trace Propagation Configuration
 
-The trace propagtor can be change after executing `distro.Run()` as follows:
+The trace propagtor can be changed by using
+[`otel.SetTextMapPropagator`](https://pkg.go.dev/go.opentelemetry.io/otel#SetTextMapPropagator)
+after `distro.Run()` is invoked e.g.:
 
 ```go
+distro.Run()
 otel.SetTextMapPropagator(propagation.TraceContext{})
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Below you will find all the configuration options supported by this distribution
 <!-- markdownlint-disable MD013 -->
 | Environment variable      | Option             | Default value  | Description |
 | ------------------------- | -------------------| -------------- | ----------- |
-| `SPLUNK_ACCESS_TOKEN`     | `WithAccessToken`  |                | The [Splunk's organization access token](https://docs.splunk.com/observability/admin/authentication-tokens/org-tokens.html). [[1](#cfg1)] |
+| `SPLUNK_ACCESS_TOKEN`     | [`WithAccessToken`](https://pkg.go.dev/github.com/signalfx/splunk-otel-go/distro#WithAccessToken)  |                | The [Splunk's organization access token](https://docs.splunk.com/observability/admin/authentication-tokens/org-tokens.html). [[1](#cfg1)] |
 | `OTEL_RESOURCE_ATTRIBUTES` |                    |                | Comma-separated list of resource attributes added to every reported span. |
 <!-- markdownlint-enable MD013 -->
 
@@ -139,7 +139,7 @@ with Splunk back-end ingest endpoint URL: `https://ingest.<REALM>.signalfx.com/v
 <!-- markdownlint-disable MD013 -->
 | Environment variable            | Option             | Default value  | Description |
 | ------------------------------- | -------------------| -------------- | ----------- |
-| `OTEL_EXPORTER_JAEGER_ENDPOINT` | `WithEndpoint`     | `http://localhost:14268/api/traces` | Jaeger Thrift HTTP endpoint for sending spans. |
+| `OTEL_EXPORTER_JAEGER_ENDPOINT` | [`WithEndpoint`](https://pkg.go.dev/github.com/signalfx/splunk-otel-go/distro#WithEndpoint)     | `http://localhost:14268/api/traces` | Jaeger Thrift HTTP endpoint for sending spans. |
 | `OTEL_EXPORTER_JAEGER_USER`     |                    |                | Username to be used for HTTP basic authentication. |
 | `OTEL_EXPORTER_JAEGER_PASSWORD` |                    |                | Password to be used for HTTP basic authentication. |
 <!-- markdownlint-enable MD013 -->

--- a/README.md
+++ b/README.md
@@ -12,16 +12,6 @@ Go](https://github.com/open-telemetry/opentelemetry-go) provides
 multiple packages that automatically instruments your Go
 application to capture and report distributed traces to Splunk APM.
 
-This Splunk distribution comes with the following defaults:
-
-- [B3 context propagation](https://github.com/openzipkin/b3-propagation).
-- [Jaeger Thrift over HTTP
-  exporter](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/jaeger)
-  configured to send spans to a locally running [Splunk OpenTelemetry Connector](https://github.com/signalfx/splunk-otel-collector)
-  (`http://localhost:14268/api/traces`).
-- Unlimited default limits for configuration options to
-  support full-fidelity traces.
-
 > :construction: This project is currently in **BETA**.
 > It is **officially supported** by Splunk.
 > However, breaking changes **MAY** be introduced.
@@ -40,6 +30,16 @@ Table of Contents:
 - [License and versioning](#license-and-versioning)
 
 ## Getting Started
+
+This Splunk distribution comes with the following defaults:
+
+- [B3 context propagation](https://github.com/openzipkin/b3-propagation).
+- [Jaeger Thrift over HTTP
+  exporter](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/jaeger)
+  configured to send spans to a locally running [Splunk OpenTelemetry Connector](https://github.com/signalfx/splunk-otel-collector)
+  (`http://localhost:14268/api/traces`).
+- Unlimited default limits for configuration options to
+  support full-fidelity traces.
 
 Install the distribution:
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ Below you will find all the configuration options supported by this distribution
 
 [<a name="cfg1">1</a>]: The [Splunk's organization access token](https://docs.splunk.com/observability/admin/authentication-tokens/org-tokens.html)
 allows exporters sending data directly to the [Splunk Observability Cloud](https://dev.splunk.com/observability/docs/apibasics/api_list/).
-To do so, the `OTEL_EXPORTER_JAEGER_ENDPOINT` or `distro.WithEndpoint` must be
-passed to `distro.Run`
+To do so, the `OTEL_EXPORTER_JAEGER_ENDPOINT` must be set
+or `distro.WithEndpoint` must be passed to `distro.Run`
 with Splunk back-end ingest endpoint URL: `https://ingest.<REALM>.signalfx.com/v2/trace`.
 
 ### Trace Configuration

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Table of Contents:
   - [Trace Configuration](#trace-configuration)
   - [Trace Exporter Configuration](#trace-exporter-configuration)
   - [Trace Propagation Configuration](#trace-propagation-configuration)
-- [License and versioning](#license-and-versioning)
+- [License](#license)
 
 ## Getting Started
 
@@ -152,7 +152,7 @@ The trace propagtor can be change after executing `distro.Run()` as follows:
 otel.SetTextMapPropagator(propagation.TraceContext{})
 ```
 
-## License and versioning
+## License
 
 The Splunk distribution of OpenTelemetry Go is a
 distribution of the [OpenTelemetry Go

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Splunk distribution of OpenTelemetry Go
 
-[![GitHub Release](https://img.shields.io/github/v/release/signalfx/splunk-otel-go)](https://github.com/signalfx/splunk-otel-go/releases)
+[![GitHub Release](https://img.shields.io/github/v/release/signalfx/splunk-otel-go?include_prereleases)](https://github.com/signalfx/splunk-otel-go/releases)
 [![Go Reference](https://pkg.go.dev/badge/github.com/signalfx/splunk-otel-go.svg)](https://pkg.go.dev/github.com/signalfx/splunk-otel-go)
 [![go.mod](https://img.shields.io/github/go-mod/go-version/signalfx/splunk-otel-go)](go.mod)
 [![LICENSE](https://img.shields.io/github/license/signalfx/splunk-otel-go)](LICENSE)
@@ -9,7 +9,7 @@
 
 The Splunk distribution of [OpenTelemetry
 Go](https://github.com/open-telemetry/opentelemetry-go) provides
-multiple installable packages that automatically instruments your Go
+multiple packages that automatically instruments your Go
 application to capture and report distributed traces to Splunk APM.
 
 This Splunk distribution comes with the following defaults:
@@ -17,16 +17,35 @@ This Splunk distribution comes with the following defaults:
 - [B3 context propagation](https://github.com/openzipkin/b3-propagation).
 - [Jaeger Thrift over HTTP
   exporter](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/jaeger)
-  configured to send spans to a locally running Splunk OpenTelemetry Connector](https://github.com/signalfx/splunk-otel-collector)
+  configured to send spans to a locally running [Splunk OpenTelemetry Connector](https://github.com/signalfx/splunk-otel-collector)
   (`http://localhost:14268/api/traces`).
 - Unlimited default limits for configuration options to
   support full-fidelity traces.
 
-> :construction: This project is currently in **BETA**. It is **officially supported** by Splunk. However, breaking changes **MAY** be introduced.
+> :construction: This project is currently in **BETA**.
+> It is **officially supported** by Splunk.
+> However, breaking changes **MAY** be introduced.
+
+Table of Contents:
+
+- [Getting Started](#getting-started)
+  - [Basic Configuration](#basic-configuration)
+- [Library Instrumentation](#library-instrumentation)
+- [Manual Instrumentation](#manual-instrumentation)
+- [Advanced Configuration](#advanced-configuration)
+  - [Splunk Distribution Configuration](#splunk-distribution-configuration)
+  - [Trace Configuration](#trace-configuration)
+  - [Trace Exporter Configuration](#trace-exporter-configuration)
+  - [Trace Propagation Configuration](#trace-propagation-configuration)
+- [License and versioning](#license-and-versioning)
 
 ## Getting Started
 
-### Bootstrapping
+Install the distribution:
+
+```sh
+go get github.com/signalfx/splunk-otel-go/distro
+```
 
 Configure OpenTelemetry using the [`distro`](./distro) package:
 
@@ -34,7 +53,7 @@ Configure OpenTelemetry using the [`distro`](./distro) package:
 package main
 
 import (
-	"context"
+  "context"
 
 	"github.com/signalfx/splunk-otel-go/distro"
 )
@@ -51,33 +70,87 @@ func main() {
 		}
 	}()
 
-    /* ... */
+	// ...
 ```
 
-### Library instrumentation
+### Basic Configuration
+
+The `service.name` resource attribute is the only configuration option that
+needs to be specified using the `OTEL_RESOURCE_ATTRIBUTES` environment variable.
+
+The `deployment.environment` and `service.version` resource attributes are not
+strictly required, but recommended to be set if they are available.
+
+It can be done in the shell:
+
+```sh
+OTEL_RESOURCE_ATTRIBUTES="service.name=my-app,service.version=1.2.3,deployment.environment=production"
+```
+
+As well as in Go code before executing `distro.Run()`:
+
+```go
+os.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=my-app,service.version=1.2.3,deployment.environment=development")
+```
+
+## Library Instrumentation
 
 Supported libraries are listed
 [here](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation).
 
-Splunk specific instrumentations:
+Additional recommended Splunk specific instrumentations:
 
 - [`splunkhttp`](./instrumentation/net/http/splunkhttp)
 
-### Manual instrumentation
+## Manual Instrumentation
 
 Documentation on how to manually instrument a Go application is available
 [here](https://opentelemetry.io/docs/go/getting-started/).
 
-## Splunk specific configuration
+## Advanced Configuration
 
+Below you will find all the configuration options supported by this distribution.
+
+### Splunk Distribution Configuration
+
+<!-- markdownlint-disable MD013 -->
 | Environment variable      | Option             | Default value  | Description |
-| ------------------------- | -------------------| -------------- | ---------------------------------------------------------------------- |
+| ------------------------- | -------------------| -------------- | ----------- |
 | `SPLUNK_ACCESS_TOKEN`     | `WithAccessToken`  |                | The [Splunk's organization access token](https://docs.splunk.com/observability/admin/authentication-tokens/org-tokens.html). [[1](#cfg1)] |
+| `OTEL_RESOURCE_ATTRIBUTES` |                    |                | Comma-separated list of resource attributes added to every reported span. |
+<!-- markdownlint-enable MD013 -->
 
 [<a name="cfg1">1</a>]: The [Splunk's organization access token](https://docs.splunk.com/observability/admin/authentication-tokens/org-tokens.html)
 allows exporters sending data directly to the [Splunk Observability Cloud](https://dev.splunk.com/observability/docs/apibasics/api_list/).
-To do so, the `OTEL_EXPORTER_JAEGER_ENDPOINT` or `distro.WithEndpoint` must be passed to `distro.Run`
+To do so, the `OTEL_EXPORTER_JAEGER_ENDPOINT` or `distro.WithEndpoint` must be
+passed to `distro.Run`
 with Splunk back-end ingest endpoint URL: `https://ingest.<REALM>.signalfx.com/v2/trace`.
+
+### Trace Configuration
+
+<!-- markdownlint-disable MD013 -->
+| Environment variable       | Option             | Default value  | Description |
+| -------------------------- | -------------------| -------------- | ----------- |
+| `OTEL_RESOURCE_ATTRIBUTES` |                    |                | Comma-separated list of resource attributes added to every reported span. |
+<!-- markdownlint-enable MD013 -->
+
+### Trace Exporter Configuration
+
+<!-- markdownlint-disable MD013 -->
+| Environment variable            | Option             | Default value  | Description |
+| ------------------------------- | -------------------| -------------- | ----------- |
+| `OTEL_EXPORTER_JAEGER_ENDPOINT` | `WithEndpoint`     | `http://localhost:14268/api/traces` | Jaeger Thrift HTTP endpoint for sending spans. |
+| `OTEL_EXPORTER_JAEGER_USER`     |                    |                | Username to be used for HTTP basic authentication. |
+| `OTEL_EXPORTER_JAEGER_PASSWORD` |                    |                | Password to be used for HTTP basic authentication. |
+<!-- markdownlint-enable MD013 -->
+
+### Trace Propagation Configuration
+
+The trace propagtor can be change after executing `distro.Run()` as follows:
+
+```go
+otel.SetTextMapPropagator(propagation.TraceContext{})
+```
 
 ## License and versioning
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,9 +2,11 @@
 
 ## Pre-Release
 
-Update go.mod for submodules to depend on the new release which will happen in the next step.
+Update go.mod for submodules to depend on the new release
+which will happen in the next step.
 
-1. Run the pre-release script. It creates a branch `pre_release_<new tag>` that will contain all release changes.
+1. Run the pre-release script. It creates a branch `pre_release_<new tag>`
+   that will contain all release changes.
 
     ```sh
     ./pre_release.sh -t <new tag>
@@ -16,12 +18,15 @@ Update go.mod for submodules to depend on the new release which will happen in t
 
 ## Tag
 
-Once the Pull Request with all the version changes has been approved and merged it is time to tag the merged commit.
+Once the Pull Request with all the version changes has been approved
+and merged it is time to tag the merged commit.
 
-***IMPORTANT***: It is critical you use the same tag that you used in the Pre-Release step!
+***IMPORTANT***: It is critical you use the same tag
+that you used in the Pre-Release step!
 Failure to do so will leave things in a broken state.
 
-***IMPORTANT***: [There is currently no way to remove an incorrectly tagged version of a Go module](https://github.com/golang/go/issues/34189).
+***IMPORTANT***:
+[There is currently no way to remove an incorrectly tagged version of a Go module](https://github.com/golang/go/issues/34189).
 It is critical you make sure the version you push upstream is correct.
 [Failure to do so will lead to minor emergencies and tough to work around](https://github.com/open-telemetry/opentelemetry-go/issues/331).
 
@@ -39,4 +44,6 @@ It is critical you make sure the version you push upstream is correct.
 
 ## Release
 
-Create a Release for the new `<new tag>` on GitHub. The release body should include all the release notes for this release taken from [CHANGELOG.md](CHANGELOG.md).
+Create a Release for the new `<new tag>` on GitHub.
+The release body should include all the release notes
+for this release taken from [CHANGELOG.md](CHANGELOG.md).

--- a/instrumentation/net/http/splunkhttp/README.md
+++ b/instrumentation/net/http/splunkhttp/README.md
@@ -18,9 +18,11 @@ import (
 func main() {
 	distro.Run()
 
-	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("Hello"))
-	})
+	var handler http.Handler = http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("Hello"))
+		}
+	)
 	handler = splunkhttp.NewHandler(handler)
 	handler = otelhttp.NewHandler(handler, "my-service")
 
@@ -32,9 +34,11 @@ func main() {
 
 ### Splunk distribution configuration
 
+<!-- markdownlint-disable MD013 -->
 | Code                                                       | Environment variable                   | Default value  | Purpose                                         |
 | ---------------------------------------------------------- | -------------------------------------- | -------------- | ----------------------------------------------- |
 | `WithTraceResponseHeader`, `TraceResponseHeaderMiddleware` | `SPLUNK_TRACE_RESPONSE_HEADER_ENABLED` | `true`         | Adds `Server-Timing` header to HTTP responses. [More](#Trace-linkage-between-the-APM-and-RUM-products) |
+<!-- markdownlint-enable MD013 -->
 
 ## Features
 
@@ -49,4 +53,5 @@ Access-Control-Expose-Headers: Server-Timing
 Server-Timing: traceparent;desc="00-<serverTraceId>-<serverSpanId>-01"
 ```
 
-This information can be later consumed by the [splunk-otel-js-web](https://github.com/signalfx/splunk-otel-js-web) library.
+This information can be later consumed by the [splunk-otel-js-web](https://github.com/signalfx/splunk-otel-js-web)
+library.


### PR DESCRIPTION
## Why

Make the docs more friendly.

## What

- Describe the configuration better. You can preview it here: https://github.com/pellared/splunk-otel-go/tree/improve-docs
- Add markdownlint.