### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The primary change of this release is updating `go.opentelemetry.io/otel*`
 dependencies to [`v1.0.0-RC3`][otel-v1.0.0-RC3] and
-`go.opentelemetry.io/contrib*` dependencies to [`v0.23.0`][contrib-v0.23.0]..
+`go.opentelemetry.io/contrib*` dependencies to [`v0.23.0`][contrib-v0.23.0].
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.6.0] - 2021-09-13
+
 The primary change of this release is updating `go.opentelemetry.io/otel*`
 dependencies to [`v1.0.0-RC3`][otel-v1.0.0-RC3] and
 `go.opentelemetry.io/contrib*` dependencies to [`v0.23.0`][contrib-v0.23.0]..
@@ -102,8 +104,8 @@ an impedance mismatch with this duplicate batching.
 - Add [`splunkhttp`](./instrumentation/net/http/splunkhttp) module providing
   additional Splunk specific instrumentation for `net/http`.
 
-[Unreleased]: https://github.com/signalfx/splunk-otel-go/compare/v0.5.0...HEAD
-[0.5.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.5.0
+[Unreleased]: https://github.com/signalfx/splunk-otel-go/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.6.0
 [0.4.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.4.0
 [0.3.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.3.0
 [0.2.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.2.0

--- a/pre_release.sh
+++ b/pre_release.sh
@@ -79,7 +79,7 @@ cp ./version.go ./version.go.bak
 sed "s/\( \"\)[0-9]*\.[0-9]*\.[0-9]*\"/\1${VERSION_IN_FILE}\"/" ./version.go.bak >./version.go
 rm -f ./version.go.bak
 
-# Update go.mod
+# Update go.mod files
 PACKAGE_DIRS=$(find . -mindepth 2 -type f -name 'go.mod' -exec dirname {} \; | egrep -v 'tools' | sed 's/^\.\///' | sort)
 
 for dir in $PACKAGE_DIRS; do
@@ -88,8 +88,8 @@ for dir in $PACKAGE_DIRS; do
 	rm -f "${dir}/go.mod.bak"
 done
 
-# Run mod-tidy to update go.sum
-make mod-tidy
+printf "Updating go.sum files\n"
+./goyek.sh mod-tidy
 
 # Add changes and commit.
 git add .

--- a/version.go
+++ b/version.go
@@ -20,5 +20,5 @@ package splunkotel // import "github.com/signalfx/splunk-otel-go"
 
 // Version is the current release version of splunk-otel-go in use.
 func Version() string {
-	return "0.5.0"
+	return "0.6.0"
 }


### PR DESCRIPTION
The primary change of this release is updating `go.opentelemetry.io/otel*`
dependencies to [`v1.0.0-RC3`][otel-v1.0.0-RC3] and
`go.opentelemetry.io/contrib*` dependencies to [`v0.23.0`][contrib-v0.23.0].

### Changed

- Update `go.opentelemetry.io/otel*` dependencies from [`v1.0.0-RC2`][otel-v1.0.0-RC2]
  to [`v1.0.0-RC3`][otel-v1.0.0-RC3].
- Update `go.opentelemetry.io/contrib*` dependencies from [`v0.22.0`][contrib-v0.22.0]
to [`v0.23.0`][contrib-v0.23.0].


[otel-v1.0.0-RC3]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.0.0-RC3
[otel-v1.0.0-RC2]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.0.0-RC2
[otel-v1.0.0-RC1]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.0.0-RC1
[otel-v0.20.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.20.0
[otel-v0.19.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.19.0

[contrib-v0.23.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.23.0
[contrib-v0.22.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.22.0
[contrib-v0.21.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.21.0
[contrib-v0.20.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.20.0
[contrib-v0.19.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.19.0