### PR TITLE
Filter tests in build pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
           - os: ubuntu-20.04
             run-script: ./goyek.sh -v -ci
           - os: windows-2019
-            run-script: .\goyek.ps1 -v -ci -skip-docker
+            run-script: .\goyek.ps1 -v -ci -skip-docker -test-short
           - os: macos-10.15
-            run-script: ./goyek.sh -v -ci -skip-docker
+            run-script: ./goyek.sh -v -ci -skip-docker -test-short
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,6 +85,8 @@ linters-settings:
     suggest-new: true
   misspell:
     locale: US
+    ignore-words:
+      - importas
   nolintlint:
     allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: false # report any unused nolint directives

--- a/build/go.mod
+++ b/build/go.mod
@@ -3,6 +3,9 @@ module github.com/signalfx/splunk-otel-go/build
 go 1.16
 
 require (
+	github.com/client9/misspell v0.3.4
+	github.com/golangci/golangci-lint v1.42.1
 	github.com/goyek/goyek v0.6.0
-	github.com/signalfx/go-pipeline v0.0.0-20210910203004-4f1bb62a830b
+	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
+	mvdan.cc/gofumpt v0.1.1
 )

--- a/build/go.sum
+++ b/build/go.sum
@@ -44,8 +44,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.4/go.mod h1:aXENhDJ1Y4lIg4EUaVTwzvYETVNZk10Pu26tevFKLUc=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/Antonboom/errname v0.1.3 h1:qKV8gSzPzBqrG/q0dgraZXJCymWt6KuD9+Y7K7xtzN8=
-github.com/Antonboom/errname v0.1.3/go.mod h1:jRXo3m0E0EuCnK3wbsSVH3X55Z4iTDLl6ZfCxwFj4TM=
+github.com/Antonboom/errname v0.1.4 h1:lGSlI42Gm4bI1e+IITtXJXvxFM8N7naWimVFKcb0McY=
+github.com/Antonboom/errname v0.1.4/go.mod h1:jRXo3m0E0EuCnK3wbsSVH3X55Z4iTDLl6ZfCxwFj4TM=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
@@ -253,8 +253,8 @@ github.com/golangci/go-misc v0.0.0-20180628070357-927a3d87b613 h1:9kfjN3AdxcbsZB
 github.com/golangci/go-misc v0.0.0-20180628070357-927a3d87b613/go.mod h1:SyvUF2NxV+sN8upjjeVYr5W7tyxaT1JVtvhKhOn2ii8=
 github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a h1:iR3fYXUjHCR97qWS8ch1y9zPNsgXThGwjKPrYfqMPks=
 github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a/go.mod h1:9qCChq59u/eW8im404Q2WWTrnBUQKjpNYKMbU4M7EFU=
-github.com/golangci/golangci-lint v1.42.0 h1:hqf1zo6zY3GKGjjBk3ttdH22tGwF6ZRpk6j6xyJmE8I=
-github.com/golangci/golangci-lint v1.42.0/go.mod h1:wgkGQnU9lOUFvTFo5QBSOvaSSddEV21Z1zYkJSbppZA=
+github.com/golangci/golangci-lint v1.42.1 h1:nC4WyrbdnNdohDVUoNKjy/4N4FTM1gCFaVeXecy6vzM=
+github.com/golangci/golangci-lint v1.42.1/go.mod h1:MuInrVlgg2jq4do6XI1jbkErbVHVbwdrLLtGv6p2wPI=
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0 h1:MfyDlzVjl1hoaPzPD4Gpb/QgoRfSBR0jdhwGyAWwMSA=
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0/go.mod h1:66R6K6P6VWk9I95jvqGxkqJxVWGFy9XlDwLwVz1RCFg=
 github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca h1:kNY3/svz5T29MYHubXix4aDDuE3RWHkPvopM/EDv/MA=
@@ -468,8 +468,8 @@ github.com/mbilski/exhaustivestruct v1.2.0 h1:wCBmUnSYufAHO6J4AVWY6ff+oxWxsVFrwg
 github.com/mbilski/exhaustivestruct v1.2.0/go.mod h1:OeTBVxQWoEmB2J2JCHmXWPJ0aksxSUOUy+nvtVEfzXc=
 github.com/mgechev/dots v0.0.0-20190921121421-c36f7dcfbb81 h1:QASJXOGm2RZ5Ardbc86qNFvby9AqkLDibfChMtAg5QM=
 github.com/mgechev/dots v0.0.0-20190921121421-c36f7dcfbb81/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=
-github.com/mgechev/revive v1.1.0 h1:TvabpsolbtlzZTyJcgMRN38MHrgi8C0DhmGE5dhscGY=
-github.com/mgechev/revive v1.1.0/go.mod h1:PKqk4L74K6wVNwY2b6fr+9Qqr/3hIsHVfZCJdbvozrY=
+github.com/mgechev/revive v1.1.1 h1:mkXNHP14Y6tfq+ocnQaiKEtgJDM41yaoyQq4qn6TD/4=
+github.com/mgechev/revive v1.1.1/go.mod h1:PKqk4L74K6wVNwY2b6fr+9Qqr/3hIsHVfZCJdbvozrY=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.35/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
@@ -548,8 +548,8 @@ github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZ
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/polyfloyd/go-errorlint v0.0.0-20210510181950-ab96adb96fea h1:Sk6Xawg57ZkjXmFYD1xCHSKN6FtYM+km51MM7Lveyyc=
-github.com/polyfloyd/go-errorlint v0.0.0-20210510181950-ab96adb96fea/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
+github.com/polyfloyd/go-errorlint v0.0.0-20210722154253-910bb7978349 h1:Kq/3kL0k033ds3tyez5lFPrfQ74fNJ+OqCclRipubwA=
+github.com/polyfloyd/go-errorlint v0.0.0-20210722154253-910bb7978349/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -610,8 +610,6 @@ github.com/shirou/gopsutil/v3 v3.21.7/go.mod h1:RGl11Y7XMTQPmHh8F0ayC6haKNBgH4PX
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/signalfx/go-pipeline v0.0.0-20210910203004-4f1bb62a830b h1:7J5z+X/mAZ+eDANxIr+blTqwoiLEqUhlZaaAlRchhUE=
-github.com/signalfx/go-pipeline v0.0.0-20210910203004-4f1bb62a830b/go.mod h1:7NArymqOPuFiDoVoJRkzTwl/XPDVPXeEhaRzpvcKpYg=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
@@ -667,8 +665,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b h1:HxLVTlqcHhFAz3nWUcuvpH7WuOMv8LQoCWmruLfFH2U=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
-github.com/tetafro/godot v1.4.8 h1:rhuUH+tBrx24yVAr6Ox3/UxcsiUPPJcGhinfLdbdew0=
-github.com/tetafro/godot v1.4.8/go.mod h1:LR3CJpxDVGlYOWn3ZZg1PgNZdTUvzsZWu8xaEohUpn8=
+github.com/tetafro/godot v1.4.9 h1:wsNd0RuUxISqqudFqchsSsMqsM188DoZVPBeKl87tP0=
+github.com/tetafro/godot v1.4.9/go.mod h1:LR3CJpxDVGlYOWn3ZZg1PgNZdTUvzsZWu8xaEohUpn8=
 github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94 h1:ig99OeTyDwQWhPe2iw9lwfQVF1KB3Q4fpP3X7/2VBG8=
 github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/tklauser/go-sysconf v0.3.7/go.mod h1:JZIdXh4RmBvZDBZ41ld2bGxRV3n4daiiqA3skYhAoQ4=

--- a/build/pipeline.go
+++ b/build/pipeline.go
@@ -1,0 +1,364 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/goyek/goyek"
+)
+
+// Config is used to configure the registered pipeline.
+type Config struct {
+	RepoPackagePrefix string // used in "test" task to specify coverpkg
+}
+
+// Pipeline contains the tasks and parameters
+// registered via Flow function.
+type Pipeline struct {
+	Tasks struct {
+		Clean        goyek.RegisteredTask
+		Fmt          goyek.RegisteredTask
+		Markdownlint goyek.RegisteredTask
+		Misspell     goyek.RegisteredTask
+		GolangciLint goyek.RegisteredTask
+		Test         goyek.RegisteredTask
+		ModTidy      goyek.RegisteredTask
+		Diff         goyek.RegisteredTask
+		Lint         goyek.RegisteredTask
+		All          goyek.RegisteredTask
+	}
+	Params struct {
+		CI         goyek.RegisteredBoolParam
+		SkipDocker goyek.RegisteredBoolParam
+	}
+}
+
+// Register registers common Go tasks.
+func Register(flow *goyek.Flow, cfg Config) Pipeline {
+	result := Pipeline{}
+
+	// parameters
+	result.Params.CI = flow.RegisterBoolParam(goyek.BoolParam{
+		Name:  "ci",
+		Usage: "Whether CI is calling the build script",
+	})
+
+	result.Params.SkipDocker = flow.RegisterBoolParam(goyek.BoolParam{
+		Name:  "skip-docker",
+		Usage: "Skip tasks using Docker",
+	})
+
+	// tasks
+	result.Tasks.Clean = flow.Register(taskClean())
+	result.Tasks.Fmt = flow.Register(taskFmt())
+	result.Tasks.Markdownlint = flow.Register(taskMarkdownLint(result.Params.SkipDocker))
+	result.Tasks.Misspell = flow.Register(taskMisspell())
+	result.Tasks.GolangciLint = flow.Register(taskGolangciLint())
+	result.Tasks.Test = flow.Register(taskTest(cfg.RepoPackagePrefix))
+	result.Tasks.ModTidy = flow.Register(taskModTidy())
+	result.Tasks.Diff = flow.Register(taskDiff(result.Params.CI))
+
+	// pipelines
+	result.Tasks.Lint = flow.Register(taskLint(goyek.Deps{
+		result.Tasks.Misspell,
+		result.Tasks.Markdownlint,
+		result.Tasks.GolangciLint,
+	}))
+	result.Tasks.All = flow.Register(taskAll(goyek.Deps{
+		result.Tasks.ModTidy,
+		result.Tasks.Fmt,
+		result.Tasks.Lint,
+		result.Tasks.Test,
+		result.Tasks.Diff,
+	}))
+	flow.DefaultTask = result.Tasks.All
+
+	return result
+}
+
+const buildDir = "build"
+
+func taskClean() goyek.Task {
+	return goyek.Task{
+		Name:  "clean",
+		Usage: "remove git ignored files",
+		Action: func(tf *goyek.TF) {
+			if err := tf.Cmd("git", "clean", "-fX").Run(); err != nil {
+				tf.Fatal(err)
+			}
+		},
+	}
+}
+
+func taskModTidy() goyek.Task {
+	return goyek.Task{
+		Name:  "mod-tidy",
+		Usage: "go mod tidy",
+		Action: func(tf *goyek.TF) {
+			ForGoModules(tf, func(tf *goyek.TF) {
+				if err := tf.Cmd("go", "mod", "tidy").Run(); err != nil {
+					tf.Error(err)
+				}
+			})
+		},
+	}
+}
+
+func taskFmt() goyek.Task {
+	return goyek.Task{
+		Name:  "fmt",
+		Usage: "gofumports",
+		Action: func(tf *goyek.TF) {
+			installFmt := tf.Cmd("go", "install", "mvdan.cc/gofumpt/gofumports")
+			installFmt.Dir = buildDir
+			if err := installFmt.Run(); err != nil {
+				tf.Fatal(err)
+			}
+
+			ForGoModules(tf, func(tf *goyek.TF) {
+				tf.Cmd("gofumports", strings.Split("-l -w -local github.com/goyek/goyek .", " ")...).Run() //nolint // it is OK if it returns error
+			})
+		},
+	}
+}
+
+func taskMarkdownLint(skipDocker goyek.RegisteredBoolParam) goyek.Task {
+	return goyek.Task{
+		Name:   "markdownlint",
+		Usage:  "markdownlint-cli (requires docker)",
+		Params: goyek.Params{skipDocker},
+		Action: func(tf *goyek.TF) {
+			if skipDocker.Get(tf) {
+				tf.Skip("skipping as Docker is needed")
+			}
+
+			if err := tf.Cmd("docker", "run", "--rm", "-v", WorkDir(tf)+":/markdown", "06kellyjac/markdownlint-cli:0.28.1", "**/*.md").Run(); err != nil {
+				tf.Error(err)
+			}
+		},
+	}
+}
+
+func taskMisspell() goyek.Task {
+	return goyek.Task{
+		Name:  "misspell",
+		Usage: "misspell",
+		Action: func(tf *goyek.TF) {
+			installFmt := tf.Cmd("go", "install", "github.com/client9/misspell/cmd/misspell")
+			installFmt.Dir = buildDir
+			if err := installFmt.Run(); err != nil {
+				tf.Fatal(err)
+			}
+
+			lint := tf.Cmd("misspell", "-error", "-locale=US", "-i=importas", ".")
+			if err := lint.Run(); err != nil {
+				tf.Fatal(err)
+			}
+		},
+	}
+}
+
+func taskGolangciLint() goyek.Task {
+	return goyek.Task{
+		Name:  "golangci-lint",
+		Usage: "golangci-lint",
+		Action: func(tf *goyek.TF) {
+			installLint := tf.Cmd("go", "install", "github.com/golangci/golangci-lint/cmd/golangci-lint")
+			installLint.Dir = buildDir
+			if err := installLint.Run(); err != nil {
+				tf.Fatal(err)
+			}
+
+			ForGoModules(tf, func(tf *goyek.TF) {
+				lint := tf.Cmd("golangci-lint", "run")
+				if err := lint.Run(); err != nil {
+					tf.Error(err)
+				}
+			})
+		},
+	}
+}
+
+func taskTest(repoPrefix string) goyek.Task {
+	return goyek.Task{
+		Name:  "test",
+		Usage: "go test with race detector and code covarage",
+		Action: func(tf *goyek.TF) {
+			// prepare test-results
+			curDir := WorkDir(tf)
+			testResultDir := filepath.Join(curDir, "test-results")
+			if err := os.RemoveAll(testResultDir); err != nil {
+				tf.Fatal(err)
+			}
+			if err := os.Mkdir(testResultDir, 0o750); err != nil { // nolint:gomnd
+				tf.Fatal(err)
+			}
+
+			// run go test race with code covarage for each Go Module
+			ForGoModules(tf, func(tf *goyek.TF) {
+				const fileNameLen = 12
+				covOut := filepath.Join(testResultDir, RandString(tf, fileNameLen)+".out")
+				if err := tf.Cmd("go", goTestArgs(repoPrefix, covOut)...).Run(); err != nil {
+					tf.Error(err)
+				}
+			})
+
+			// merge the coverage output files into a single coverage.out file
+			installGocovmerge := tf.Cmd("go", "install", "github.com/wadey/gocovmerge")
+			installGocovmerge.Dir = buildDir
+			if err := installGocovmerge.Run(); err != nil {
+				tf.Fatal(err)
+			}
+
+			var covFiles []string
+			files, err := os.ReadDir(testResultDir)
+			if err != nil {
+				tf.Fatal(err)
+			}
+			for _, file := range files {
+				covFiles = append(covFiles, file.Name())
+			}
+
+			mergedCovFile, err := os.Create(filepath.Join(testResultDir, "coverage.out"))
+			if err != nil {
+				tf.Fatal(err)
+			}
+			defer func() {
+				if err := mergedCovFile.Close(); err != nil {
+					tf.Fatal(err)
+				}
+			}()
+
+			gocovmerge := tf.Cmd("gocovmerge", covFiles...)
+			gocovmerge.Dir = testResultDir
+			gocovmerge.Stdout = mergedCovFile
+			if err := gocovmerge.Run(); err != nil {
+				tf.Fatal(err)
+			}
+		},
+	}
+}
+
+func goTestArgs(repoPrefix, covOut string) []string {
+	result := []string{"test", "-race", "-covermode=atomic"}
+	if repoPrefix != "" {
+		result = append(result, "-coverpkg="+repoPrefix+"/...")
+	}
+	result = append(result, "-coverprofile="+covOut, "./...")
+	return result
+}
+
+func taskDiff(ci goyek.RegisteredBoolParam) goyek.Task {
+	return goyek.Task{
+		Name:   "diff",
+		Usage:  "git diff",
+		Params: goyek.Params{ci},
+		Action: func(tf *goyek.TF) {
+			if !ci.Get(tf) {
+				tf.Skip("ci param is not set, skipping")
+			}
+
+			if err := tf.Cmd("git", "diff", "--exit-code").Run(); err != nil {
+				tf.Error(err)
+			}
+
+			cmd := tf.Cmd("git", "status", "--porcelain")
+			sb := &strings.Builder{}
+			cmd.Stdout = io.MultiWriter(tf.Output(), sb)
+			if err := cmd.Run(); err != nil {
+				tf.Error(err)
+			}
+			if sb.Len() > 0 {
+				tf.Error("git status --porcelain returned output")
+			}
+		},
+	}
+}
+
+func taskLint(deps goyek.Deps) goyek.Task {
+	return goyek.Task{
+		Name:  "lint",
+		Usage: "all linters",
+		Deps:  deps,
+	}
+}
+
+func taskAll(deps goyek.Deps) goyek.Task {
+	return goyek.Task{
+		Name:  "all",
+		Usage: "build pipeline",
+		Deps:  deps,
+	}
+}
+
+// ForGoModules is a helper that executes given function
+// in each directory containing go.mod file.
+func ForGoModules(tf *goyek.TF, fn func(tf *goyek.TF)) {
+	curDir := WorkDir(tf)
+	_ = filepath.WalkDir(curDir, func(path string, dir fs.DirEntry, err error) error {
+		if dir.Name() != "go.mod" {
+			return nil
+		}
+
+		goModDir := filepath.Dir(path)
+		tf.Log("Go Module:", goModDir)
+		if err := os.Chdir(goModDir); err != nil {
+			tf.Fatal(err)
+		}
+
+		fn(tf) // execute function in file containing go.mod
+
+		return nil
+	})
+
+	defer ChDir(tf, curDir)
+}
+
+// WorkDir returns current working directory.
+func WorkDir(tf *goyek.TF) string {
+	curDir, err := os.Getwd()
+	if err != nil {
+		tf.Fatal(err)
+	}
+	return curDir
+}
+
+// ChDir changes the working directory.
+func ChDir(tf *goyek.TF, path string) {
+	if err := os.Chdir(path); err != nil {
+		tf.Fatal(err)
+	}
+}
+
+// RandString returns securely generated hex-string.
+func RandString(tf *goyek.TF, length int) string {
+	n := length / 2
+	if length%2 != 0 {
+		n++
+	}
+
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		tf.Fatal(err)
+	}
+	return hex.EncodeToString(b)[:length]
+}

--- a/build/pipeline_test.go
+++ b/build/pipeline_test.go
@@ -15,14 +15,23 @@
 package main
 
 import (
-	"github.com/goyek/goyek"
+	"strconv"
+	"testing"
 )
 
-func main() {
-	flow := &goyek.Flow{}
-	cfg := Config{
-		RepoPackagePrefix: "github.com/signalfx/splunk-otel-go",
+func TestRandString(t *testing.T) {
+	testCases := []int{
+		0,
+		1,
+		2,
+		5,
+		16,
 	}
-	Register(flow, cfg)
-	flow.Main()
+	for _, length := range testCases {
+		t.Run(strconv.Itoa(length), func(t *testing.T) {
+			if got := RandString(nil, length); len(got) != length {
+				t.Errorf("got length %v, want %v", len(got), length)
+			}
+		})
+	}
 }

--- a/build/tools.go
+++ b/build/tools.go
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+//go:build tools
+// +build tools
 
+package tools
+
+// Manage tool dependencies via go.mod.
+//
+// https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+// https://github.com/golang/go/issues/25922
 import (
-	"github.com/goyek/goyek"
+	_ "github.com/client9/misspell/cmd/misspell"
+	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	_ "github.com/wadey/gocovmerge"
+	_ "mvdan.cc/gofumpt/gofumports"
 )
-
-func main() {
-	flow := &goyek.Flow{}
-	cfg := Config{
-		RepoPackagePrefix: "github.com/signalfx/splunk-otel-go",
-	}
-	Register(flow, cfg)
-	flow.Main()
-}

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/integration_test.go
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/integration_test.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux
-// +build linux
-
 package test
 
 // Build restrictions come from docker not being available on Windows and

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/test/integration_test.go
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/test/integration_test.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux
-// +build linux
-
 package test
 
 // Build restrictions come from docker not being available on Windows and

--- a/instrumentation/github.com/lib/pq/splunkpq/test/integration_test.go
+++ b/instrumentation/github.com/lib/pq/splunkpq/test/integration_test.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux
-// +build linux
-
 package test
 
 // Build restrictions come from docker not being available on Windows and


### PR DESCRIPTION
## Why

Address https://github.com/signalfx/splunk-otel-go/issues/122

## What

- Inline code from https://github.com/signalfx/go-pipeline to make it easier to modify/develop. I do not believe any other repo would use it anyway. The code in `piepline.go` should still be reusable.
- Add possibility to run only short tests using `-test-short` param
- Remove the `linux` build tags from integration tests
- Handle the `-v` param in the `test` task

Example usage:
```
$ ./goyek.sh test -v -test-short
===== TASK  test
Go Module: /home/rpajak/repos/splunk-otel-go/build
Cmd: go test -race -covermode=atomic -v -short -coverpkg=github.com/signalfx/splunk-otel-go/... -coverprofile=/home/rpajak/repos/splunk-otel-go/test-results/1b52cfb083dd.out ./...
=== RUN   TestRandString
=== RUN   TestRandString/0
=== RUN   TestRandString/1
...
```

## Other

I want to archive https://github.com/signalfx/go-pipeline after this PR is merged.