### PR TITLE
Add github.com/graph-gophers/graphql-go instrumentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,10 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "gomod"
+    directory: "/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
     directory: "/instrumentation/github.com/jackc/pgx/splunkpgx"
     schedule:
       interval: "daily"

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Additional recommended Splunk specific instrumentations:
 - [`splunkclient-go`](./instrumentation/k8s.io/client-go/splunkclient-go)
 - [`splunkdns`](./instrumentation/github.com/miekg/dns/splunkdns)
 - [`splunkgorm`](./instrumentation/github.com/jinzhu/gorm/splunkgorm)
+- [`splunkgraphql`](./instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql)
 - [`splunkhttp`](./instrumentation/net/http/splunkhttp)
 - [`splunkkafka`](./instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka)
 - [`splunkleveldb`](./instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb)

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/README.md
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/README.md
@@ -1,0 +1,12 @@
+# Splunk instrumentation for `github.com/graph-gophers/graphql-go`
+
+module github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql
+
+This package provides OpenTelemetry instrumentation for the
+[graphql](https://github.com/graph-gophers/graphql-go) package.
+
+## Getting Started
+
+This package provides an implementation of the `graphql.Tracer` that can be
+used to trace `graphql` operations. See [example_test.go](./example_test.go)
+for more information.

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/go.mod
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/go.mod
@@ -1,0 +1,3 @@
+module github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql
+
+go 1.16


### PR DESCRIPTION
This new module instruments the `github.com/graph-gophers/graphql-go` module.

- [ ] Comply with OpenTelemetry HTTP semantic conventions
- [ ] Package documentation
- [ ] Exported objects are documented
- [ ] Tests and linting are passing
- [ ] Includes dependabot config
- [ ] Library added to README.md
- [ ] CHANGELOG.md updated