### PR TITLE
Add Splunk notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,4 +177,6 @@ project](https://github.com/open-telemetry/opentelemetry-go). It is
 released under the terms of the Apache Software License version 2.0. See [the
 license file](./LICENSE) for more details.
 
->ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk
+SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html)
+for more information.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Splunk distribution of OpenTelemetry Go
+# Splunk Distribution of OpenTelemetry Go
 
 [![GitHub Release](https://img.shields.io/github/v/release/signalfx/splunk-otel-go?include_prereleases)](https://github.com/signalfx/splunk-otel-go/releases)
 [![Go Reference](https://pkg.go.dev/badge/github.com/signalfx/splunk-otel-go.svg)](https://pkg.go.dev/github.com/signalfx/splunk-otel-go)
@@ -176,3 +176,5 @@ distribution of the [OpenTelemetry Go
 project](https://github.com/open-telemetry/opentelemetry-go). It is
 released under the terms of the Apache Software License version 2.0. See [the
 license file](./LICENSE) for more details.
+
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.


### PR DESCRIPTION
This small PR adds the acquisition notice with a link to the README file.