### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-## [0.7.0] - 2022-01-12
+## [0.7.0] - 2022-01-13
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,7 +168,8 @@ an impedance mismatch with this duplicate batching.
 - Add [`splunkhttp`](./instrumentation/net/http/splunkhttp) module providing
   additional Splunk specific instrumentation for `net/http`.
 
-[Unreleased]: https://github.com/signalfx/splunk-otel-go/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/signalfx/splunk-otel-go/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.7.0
 [0.6.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.6.0
 [0.4.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.4.0
 [0.3.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.7.0] - 2022-01-12
+
 ### Added
 
 - Add the
@@ -66,9 +68,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Update `go.opentelemetry.io/otel*` dependencies from [`v1.0.0-RC3`][otel-v1.0.0-RC3]
-  to [`v1.0.0`][otel-v1.0.0].
+  to [`v1.3.0`][otel-v1.3.0].
 - Update `go.opentelemetry.io/contrib*` dependencies from [`v0.23.0`][contrib-v0.23.0]
-to [`v0.24.0`][contrib-v0.24.0].
+to [`v0.28.0`][contrib-v0.28.0].
 
 ## [0.6.0] - 2021-09-13
 
@@ -173,14 +175,14 @@ an impedance mismatch with this duplicate batching.
 [0.2.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.2.0
 [0.1.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.1.0
 
-[otel-v1.0.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.0.0
+[otel-v1.3.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.3.0
 [otel-v1.0.0-RC3]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.0.0-RC3
 [otel-v1.0.0-RC2]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.0.0-RC2
 [otel-v1.0.0-RC1]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.0.0-RC1
 [otel-v0.20.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.20.0
 [otel-v0.19.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.19.0
 
-[contrib-v0.24.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.24.0
+[contrib-v0.28.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.28.0
 [contrib-v0.23.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.23.0
 [contrib-v0.22.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.22.0
 [contrib-v0.21.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.21.0

--- a/instrumentation/database/sql/splunksql/go.mod
+++ b/instrumentation/database/sql/splunksql/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go v0.6.0
+	github.com/signalfx/splunk-otel-go v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/trace v1.3.0

--- a/instrumentation/database/sql/splunksql/test/go.mod
+++ b/instrumentation/database/sql/splunksql/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-20210921155913-50ba051311e1
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/database/sql/splunksql/test/go.mod
+++ b/instrumentation/database/sql/splunksql/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.0.0-20210921155913-50ba051311e1
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-20210921155913-50ba051311e1
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/confluentinc/confluent-kafka-go v1.8.2
-	github.com/signalfx/splunk-otel-go v0.6.0
+	github.com/signalfx/splunk-otel-go v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/trace v1.3.0

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/confluentinc/confluent-kafka-go v1.8.2
 	github.com/ory/dockertest/v3 v3.8.1
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/confluentinc/confluent-kafka-go v1.8.2
 	github.com/ory/dockertest/v3 v3.8.1
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/github.com/go-chi/chi/splunkchi/go.mod
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/go-chi/chi v1.5.4
-	github.com/signalfx/splunk-otel-go v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go v0.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/trace v1.3.0
 )

--- a/instrumentation/github.com/go-chi/chi/splunkchi/go.mod
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/go-chi/chi v1.5.4
-	github.com/signalfx/splunk-otel-go v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go v0.7.0-00010101000000-000000000000
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/trace v1.3.0
 )

--- a/instrumentation/github.com/go-chi/chi/splunkchi/test/go.mod
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/go-chi/chi v1.5.4
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/github.com/go-chi/chi/splunkchi/test/go.mod
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/go-chi/chi v1.5.4
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/go.mod
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/signalfx/splunk-otel-go v0.7.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/go.mod
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/go.mod
@@ -4,8 +4,8 @@ go 1.16
 
 require (
 	github.com/go-sql-driver/mysql v1.6.0
-	github.com/signalfx/splunk-otel-go v0.6.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go v0.7.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/go.mod
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/go.mod
@@ -4,8 +4,8 @@ go 1.16
 
 require (
 	github.com/ory/dockertest/v3 v3.8.1
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.0.0-00010101000000-000000000000
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/go.mod
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/go.mod
@@ -4,8 +4,8 @@ go 1.16
 
 require (
 	github.com/ory/dockertest/v3 v3.8.1
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-00010101000000-000000000000
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/go.mod
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/gomodule/redigo v1.8.8
-	github.com/signalfx/splunk-otel-go v0.6.0
+	github.com/signalfx/splunk-otel-go v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/trace v1.3.0

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/go.mod
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.0.3 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/go.mod
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.0.3 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/go.mod
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/graph-gophers/graphql-go v1.2.0
-	github.com/signalfx/splunk-otel-go v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go v0.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/trace v1.3.0
 )

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/go.mod
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/graph-gophers/graphql-go v1.2.0
-	github.com/signalfx/splunk-otel-go v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go v0.7.0-00010101000000-000000000000
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/trace v1.3.0
 )

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test/go.mod
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/graph-gophers/graphql-go v1.2.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel/sdk v1.3.0
 	go.opentelemetry.io/otel/trace v1.3.0

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test/go.mod
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/graph-gophers/graphql-go v1.2.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel/sdk v1.3.0
 	go.opentelemetry.io/otel/trace v1.3.0

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/go.mod
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/jackc/pgx/v4 v4.14.1
 	github.com/signalfx/splunk-otel-go v0.7.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/go.mod
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/jackc/fake v0.0.0-20150926172116-812a484cc733 // indirect
 	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/jackc/pgx/v4 v4.14.1
-	github.com/signalfx/splunk-otel-go v0.6.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go v0.7.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/test/go.mod
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/test/go.mod
@@ -4,8 +4,8 @@ go 1.16
 
 require (
 	github.com/ory/dockertest/v3 v3.8.1
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-00010101000000-000000000000
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/test/go.mod
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/test/go.mod
@@ -4,8 +4,8 @@ go 1.16
 
 require (
 	github.com/ory/dockertest/v3 v3.8.1
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.0.0-00010101000000-000000000000
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/github.com/jinzhu/gorm/splunkgorm/go.mod
+++ b/instrumentation/github.com/jinzhu/gorm/splunkgorm/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/jinzhu/gorm v1.9.16
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/instrumentation/github.com/jinzhu/gorm/splunkgorm/go.mod
+++ b/instrumentation/github.com/jinzhu/gorm/splunkgorm/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/jinzhu/gorm v1.9.16
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/instrumentation/github.com/jmoiron/sqlx/splunksqlx/go.mod
+++ b/instrumentation/github.com/jmoiron/sqlx/splunksqlx/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/jmoiron/sqlx v1.3.4
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/instrumentation/github.com/jmoiron/sqlx/splunksqlx/go.mod
+++ b/instrumentation/github.com/jmoiron/sqlx/splunksqlx/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/jmoiron/sqlx v1.3.4
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test/go.mod
+++ b/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.28.0
 	go.opentelemetry.io/otel v1.3.0

--- a/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test/go.mod
+++ b/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.28.0
 	go.opentelemetry.io/otel v1.3.0

--- a/instrumentation/github.com/lib/pq/splunkpq/go.mod
+++ b/instrumentation/github.com/lib/pq/splunkpq/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/lib/pq v1.10.4
 	github.com/signalfx/splunk-otel-go v0.7.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/instrumentation/github.com/lib/pq/splunkpq/go.mod
+++ b/instrumentation/github.com/lib/pq/splunkpq/go.mod
@@ -4,8 +4,8 @@ go 1.16
 
 require (
 	github.com/lib/pq v1.10.4
-	github.com/signalfx/splunk-otel-go v0.6.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go v0.7.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/instrumentation/github.com/lib/pq/splunkpq/test/go.mod
+++ b/instrumentation/github.com/lib/pq/splunkpq/test/go.mod
@@ -10,8 +10,8 @@ replace (
 
 require (
 	github.com/ory/dockertest/v3 v3.8.1
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.0.0-00010101000000-000000000000
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/github.com/lib/pq/splunkpq/test/go.mod
+++ b/instrumentation/github.com/lib/pq/splunkpq/test/go.mod
@@ -10,8 +10,8 @@ replace (
 
 require (
 	github.com/ory/dockertest/v3 v3.8.1
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0-00010101000000-000000000000
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.7.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/github.com/miekg/dns/splunkdns/go.mod
+++ b/instrumentation/github.com/miekg/dns/splunkdns/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/miekg/dns v1.1.45
-	github.com/signalfx/splunk-otel-go v0.6.0
+	github.com/signalfx/splunk-otel-go v0.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/trace v1.3.0
 )

--- a/instrumentation/github.com/miekg/dns/splunkdns/test/go.mod
+++ b/instrumentation/github.com/miekg/dns/splunkdns/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/miekg/dns v1.1.45
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/github.com/miekg/dns/splunkdns/test/go.mod
+++ b/instrumentation/github.com/miekg/dns/splunkdns/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/miekg/dns v1.1.45
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/go.mod
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/gole
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go v0.6.0
+	github.com/signalfx/splunk-otel-go v0.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/goleveldb v1.0.0
 	go.opentelemetry.io/otel v1.3.0

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/go.mod
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/gole
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/goleveldb v1.0.0
 	go.opentelemetry.io/otel v1.3.0

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/go.mod
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/gole
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb v0.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/goleveldb v1.0.0
 	go.opentelemetry.io/otel v1.3.0

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/go.mod
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/bun
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go v0.6.0
+	github.com/signalfx/splunk-otel-go v0.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/tidwall/buntdb v1.2.9
 	go.opentelemetry.io/otel v1.3.0

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/go.mod
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/bun
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	github.com/tidwall/buntdb v1.2.9
 	go.opentelemetry.io/otel v1.3.0

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/go.mod
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/bun
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb v0.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/tidwall/buntdb v1.2.9
 	go.opentelemetry.io/otel v1.3.0

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/go.mod
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/olivere/elastic/v7 v7.0.31
-	github.com/signalfx/splunk-otel-go v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/trace v1.3.0

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/go.mod
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/olivere/elastic/v7 v7.0.31
-	github.com/signalfx/splunk-otel-go v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/trace v1.3.0

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/go.mod
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.0.3 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/go.mod
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.0.3 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/instrumentation/k8s.io/client-go/splunkclient-go/go.mod
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splun
 go 1.17
 
 require (
-	github.com/signalfx/splunk-otel-go v0.6.0
+	github.com/signalfx/splunk-otel-go v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/trace v1.3.0

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/go.mod
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splun
 go 1.17
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go v0.7.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0
@@ -16,7 +16,7 @@ require (
 	github.com/go-logr/stdr v1.2.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go v0.6.0 // indirect
+	github.com/signalfx/splunk-otel-go v0.7.0 // indirect
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e // indirect

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/go.mod
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splun
 go 1.17
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go v0.7.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go v0.7.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0

--- a/version.go
+++ b/version.go
@@ -20,5 +20,5 @@ package splunkotel // import "github.com/signalfx/splunk-otel-go"
 
 // Version is the current release version of splunk-otel-go in use.
 func Version() string {
-	return "0.6.0"
+	return "0.7.0"
 }


### PR DESCRIPTION
### Added

- Add the `github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql` instrumentation for the `database/sql` package. (#88)
- Add the `github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql` instrumentation for the `github.com/go-sql-driver/mysql` package. (#90)
- Add the `github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx` instrumentation for the `github.com/jackc/pgx` package. (#91)
- Add the `github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq` instrumentation for the `github.com/lib/pq` package. (#92)
- Add the `github.com/signalfx/splunk-otel-go/instrumentation/github.com/jmoiron/sqlx/splunksqlx`
  instrumentation for the `github.com/jmoiron/sqlx` package. (#93)
- Add the `github.com/signalfx/splunk-otel-go/instrumentation/github.com/jinzhu/gorm/splunkgorm` instrumentation for the `github.com/jinzhu/gorm` package. (#98)
- Add the `github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka` instrumentation for the `github.com/confluentinc/confluent-kafka-go/kafka` package. (#100)
- Add the `github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns` instrumentation for the `github.com/miekg/dns` package. (#155)
- Add the `github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb` instrumentation for the `github.com/syndtr/goleveldb/leveldb` package. (#186)
- Add the `github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb` instrumentation for the `github.com/tidwall/buntdb` package. (#228)
- Add the `github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go` instrumentation for the `k8s.io/client-go` package. (#224)
- Add the `github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi` instrumentation for the `github.com/go-chi/chi` package. (#227)
- Add the `github.com/signalfx/splunk-otel-go/instrumentation/graphql-gophers/graphql-go/splunkgraphql` instrumentation for the `github.com/graph-gophers/graphql-go` module. (#232)
- Add the `github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter` instrumentation for the `github.com/julienschmidt/httprouter` package. (#273)
- Add the `github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo` instrumentation for the `github.com/gomodule/redigo` package. (#288)
- Add the `github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic` instrumentation for the `gopkg.in/olivere/elastic` package. (#311)

### Changed

- Update `go.opentelemetry.io/otel*` dependencies from [`v1.0.0-RC3`][otel-v1.0.0-RC3] to [`v1.3.0`][otel-v1.3.0].
- Update `go.opentelemetry.io/contrib*` dependencies from [`v0.23.0`][contrib-v0.23.0] to [`v0.28.0`][contrib-v0.28.0].

[otel-v1.3.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.3.0
[otel-v1.0.0-RC3]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.0.0-RC3j
[contrib-v0.28.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.28.0
[contrib-v0.23.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.23.0