### PR TITLE
Add Splunk span limit defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add the `WithLogger` option to `github.com/signalfx/splunk-otel-go/distro`
   along with parsing of the `OTEL_LOG_LEVEL` environment variable to set the
   logging level of the default logger used. (#336)
+- Add the `WithSpanLimits` option to
+  `github.com/signalfx/splunk-otel-go/distro` to set the span limits used.
+  (#723)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add the `WithLogger` option to `github.com/signalfx/splunk-otel-go/distro`
   along with parsing of the `OTEL_LOG_LEVEL` environment variable to set the
   logging level of the default logger used. (#336)
-- Add the `WithSpanLimits` option to
-  `github.com/signalfx/splunk-otel-go/distro` to set the span limits used.
-  (#723)
 
 ### Changed
 
@@ -40,6 +37,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   (#720)
 - The `OTEL_TRACES_SAMPLER` environment variable is now honored instead of only
   defaulting to an always-on sampler. (#724)
+- Set span limits to the Splunk defaults (the link count is limited to 1000,
+  the attribute value length is limited to 12000, and all other limts are set
+  to be unlimited) if they are not set by the user with environment variables.
+  (#723)
 
 ### Fixed
 

--- a/distro/config.go
+++ b/distro/config.go
@@ -297,20 +297,3 @@ func WithLogger(l logr.Logger) Option {
 		c.Logger = l
 	})
 }
-
-// WithSpanLimits configures the span limits used by the distro.
-//
-// The OpenTelemetry environment limit variables
-// (OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT, OTEL_ATTRIBUTE_COUNT_LIMIT,
-// OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT, OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
-// OTEL_SPAN_EVENT_COUNT_LIMIT, OTEL_SPAN_LINK_COUNT_LIMIT,
-// OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT, OTEL_LINK_ATTRIBUTE_COUNT_LIMIT) are used
-// if this option is not provided.
-//
-// By default, the link count is limited to 1000, the attribute value length
-// is limited to 12000, and all other limts are set to be unlimited.
-func WithSpanLimits(limits trace.SpanLimits) Option {
-	return optionFunc(func(c *config) {
-		c.SpanLimits = &limits
-	})
-}

--- a/distro/config.go
+++ b/distro/config.go
@@ -46,9 +46,6 @@ const (
 	// Logging level to set when using the default logger.
 	otelLogLevelKey = "OTEL_LOG_LEVEL"
 
-	// FIXME: support OTEL_SPAN_LINK_COUNT_LIMIT
-	// FIXME: support OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
-
 	// splunkMetricsEndpointKey defines the endpoint Splunk specific metrics
 	// are sent. This is not currently supported.
 	splunkMetricsEndpointKey = "SPLUNK_METRICS_ENDPOINT"

--- a/distro/config.go
+++ b/distro/config.go
@@ -74,7 +74,7 @@ type exporterConfig struct {
 type config struct {
 	Logger     logr.Logger
 	Propagator propagation.TextMapPropagator
-	SpanLimits trace.SpanLimits
+	SpanLimits *trace.SpanLimits
 
 	ExportConfig      *exporterConfig
 	TraceExporterFunc traceExporterFunc
@@ -314,6 +314,6 @@ func WithLogger(l logr.Logger) Option {
 // is limited to 12000, and all other limts are set to be unlimited.
 func WithSpanLimits(limits trace.SpanLimits) Option {
 	return optionFunc(func(c *config) {
-		c.SpanLimits = limits
+		c.SpanLimits = &limits
 	})
 }

--- a/distro/config_test.go
+++ b/distro/config_test.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/contrib/propagators/jaeger"
 	"go.opentelemetry.io/contrib/propagators/ot"
 	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/trace"
 )
 
 type KeyValue struct {
@@ -114,6 +115,48 @@ var ConfigurationTests = []*ConfigFieldTest{
 				},
 				AssertionFunc: func(t *testing.T, c *config) {
 					assert.Equal(t, propagation.TraceContext{}, c.Propagator)
+				},
+			},
+		},
+	},
+	{
+		Name: "WithSpanLimits",
+		ValueFunc: func(c *config) interface{} {
+			return c.SpanLimits
+		},
+		DefaultValue: &trace.SpanLimits{
+			AttributeValueLengthLimit:   12000,
+			AttributeCountLimit:         -1,
+			EventCountLimit:             -1,
+			LinkCountLimit:              1000,
+			AttributePerEventCountLimit: -1,
+			AttributePerLinkCountLimit:  -1,
+		},
+		EnvironmentTests: []KeyValue{
+			{Key: attributeValueLengthKey, Value: "10"},
+			{Key: spanAttributeValueLengthKey, Value: "10"},
+			{Key: attributeCountKey, Value: "10"},
+			{Key: spanAttributeCountKey, Value: "10"},
+			{Key: spanEventCountKey, Value: "10"},
+			{Key: spanEventAttributeCountKey, Value: "10"},
+			{Key: spanLinkCountKey, Value: "10"},
+			{Key: spanLinkAttributeCountKey, Value: "10"},
+		},
+		OptionTests: []OptionTest{
+			{
+				Name: "valid override",
+				Options: []Option{
+					WithSpanLimits(trace.SpanLimits{
+						AttributeValueLengthLimit:   100,
+						AttributeCountLimit:         100,
+						EventCountLimit:             100,
+						LinkCountLimit:              100,
+						AttributePerEventCountLimit: 100,
+						AttributePerLinkCountLimit:  100,
+					}),
+				},
+				AssertionFunc: func(t *testing.T, c *config) {
+					assert.Equal(t, expectedSL(100, 100, 100, 100, 100, 100), c.SpanLimits)
 				},
 			},
 		},

--- a/distro/config_test.go
+++ b/distro/config_test.go
@@ -25,7 +25,6 @@ import (
 	"go.opentelemetry.io/contrib/propagators/jaeger"
 	"go.opentelemetry.io/contrib/propagators/ot"
 	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/trace"
 )
 
 type KeyValue struct {
@@ -115,48 +114,6 @@ var ConfigurationTests = []*ConfigFieldTest{
 				},
 				AssertionFunc: func(t *testing.T, c *config) {
 					assert.Equal(t, propagation.TraceContext{}, c.Propagator)
-				},
-			},
-		},
-	},
-	{
-		Name: "WithSpanLimits",
-		ValueFunc: func(c *config) interface{} {
-			return c.SpanLimits
-		},
-		DefaultValue: &trace.SpanLimits{
-			AttributeValueLengthLimit:   12000,
-			AttributeCountLimit:         -1,
-			EventCountLimit:             -1,
-			LinkCountLimit:              1000,
-			AttributePerEventCountLimit: -1,
-			AttributePerLinkCountLimit:  -1,
-		},
-		EnvironmentTests: []KeyValue{
-			{Key: attributeValueLengthKey, Value: "10"},
-			{Key: spanAttributeValueLengthKey, Value: "10"},
-			{Key: attributeCountKey, Value: "10"},
-			{Key: spanAttributeCountKey, Value: "10"},
-			{Key: spanEventCountKey, Value: "10"},
-			{Key: spanEventAttributeCountKey, Value: "10"},
-			{Key: spanLinkCountKey, Value: "10"},
-			{Key: spanLinkAttributeCountKey, Value: "10"},
-		},
-		OptionTests: []OptionTest{
-			{
-				Name: "valid override",
-				Options: []Option{
-					WithSpanLimits(trace.SpanLimits{
-						AttributeValueLengthLimit:   100,
-						AttributeCountLimit:         100,
-						EventCountLimit:             100,
-						LinkCountLimit:              100,
-						AttributePerEventCountLimit: 100,
-						AttributePerLinkCountLimit:  100,
-					}),
-				},
-				AssertionFunc: func(t *testing.T, c *config) {
-					assert.Equal(t, expectedSL(100, 100, 100, 100, 100, 100), c.SpanLimits)
 				},
 			},
 		},

--- a/distro/limits.go
+++ b/distro/limits.go
@@ -120,7 +120,6 @@ func (s spanLimitSource) envsSet() bool {
 		}
 	}
 	return false
-
 }
 
 // applyDefaults will apply the default to the corresponding limit in limits

--- a/distro/limits.go
+++ b/distro/limits.go
@@ -21,117 +21,26 @@ import (
 )
 
 const (
-	attributeValueLengthKey     = "OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT"
-	attributeCountKey           = "OTEL_ATTRIBUTE_COUNT_LIMIT"
-	spanAttributeValueLengthKey = "OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT"
-	spanAttributeCountKey       = "OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT"
-	spanEventCountKey           = "OTEL_SPAN_EVENT_COUNT_LIMIT"
-	spanEventAttributeCountKey  = "OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT"
-	spanLinkCountKey            = "OTEL_SPAN_LINK_COUNT_LIMIT"
-	spanLinkAttributeCountKey   = "OTEL_LINK_ATTRIBUTE_COUNT_LIMIT"
+	attributeValueLengthKey         = "OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT"
+	spanAttributeValueLengthKey     = "OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT"
+	spanAttributeValueLengthDefault = 12000
+
+	attributeCountKey         = "OTEL_ATTRIBUTE_COUNT_LIMIT"
+	spanAttributeCountKey     = "OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT"
+	spanAttributeCountDefault = -1 // Unlimited.
+
+	spanEventCountKey     = "OTEL_SPAN_EVENT_COUNT_LIMIT"
+	spanEventCountDefault = -1 // Unlimited.
+
+	spanEventAttributeCountKey     = "OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT"
+	spanEventAttributeCountDefault = -1 // Unlimited.
+
+	spanLinkCountKey     = "OTEL_SPAN_LINK_COUNT_LIMIT"
+	spanLinkCountDefault = 1000
+
+	spanLinkAttributeCountKey     = "OTEL_LINK_ATTRIBUTE_COUNT_LIMIT"
+	spanLinkAttributeCountDefault = -1 // Unlimited.
 )
-
-// sources are span limit sources with Splunk defaults.
-var sources = spanLimitSources{
-	// Maximum allowed attribute value size for a span.
-	{
-		envs: []string{attributeValueLengthKey, spanAttributeValueLengthKey},
-		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
-			limits.AttributeValueLengthLimit = 12000
-			return limits
-		},
-	},
-
-	// Maximum allowed attribute count for a span.
-	{
-		envs: []string{attributeCountKey, spanAttributeCountKey},
-		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
-			// Unlimited.
-			limits.AttributeCountLimit = -1
-			return limits
-		},
-	},
-
-	// Maximum allowed span event count.
-	{
-		envs: []string{spanEventCountKey},
-		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
-			// Unlimited.
-			limits.EventCountLimit = -1
-			return limits
-		},
-	},
-
-	// Maximum allowed attributes per span event.
-	{
-		envs: []string{spanEventAttributeCountKey},
-		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
-			// Unlimited.
-			limits.AttributePerEventCountLimit = -1
-			return limits
-		},
-	},
-
-	// Maximum allowed span link count.
-	{
-		envs: []string{spanLinkCountKey},
-		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
-			limits.LinkCountLimit = 1000
-			return limits
-		},
-	},
-
-	// Maximum allowed attributes per span link.
-	{
-		envs: []string{spanLinkAttributeCountKey},
-		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
-			// Unlimited.
-			limits.AttributePerLinkCountLimit = -1
-			return limits
-		},
-	},
-}
-
-// spanLimitSources is a collection of all the sources of configuration for
-// a group of spans limits.
-type spanLimitSources []spanLimitSource
-
-// applyDefaults will apply the defaults to all limits that do not have the
-// associated limit's environment variables set.
-func (s spanLimitSources) applyDefaults(limits trace.SpanLimits) trace.SpanLimits {
-	for _, source := range s {
-		limits = source.applyDefault(limits)
-	}
-	return limits
-}
-
-// spanLimitSource are all the sources a span limit is configured from and the
-// default value used if none of those sources are used.
-type spanLimitSource struct {
-	envs       []string
-	setDefault func(limits trace.SpanLimits) trace.SpanLimits
-}
-
-// envsSet returns if any environment variable for s is set.
-func (s spanLimitSource) envsSet() bool {
-	for _, env := range s.envs {
-		if _, ok := os.LookupEnv(env); ok {
-			return true
-		}
-	}
-	return false
-}
-
-// applyDefaults will apply the default to the corresponding limit in limits
-// if the associated environment variables are not set.
-func (s spanLimitSource) applyDefault(limits trace.SpanLimits) trace.SpanLimits {
-	if !s.envsSet() {
-		// Panic if setDefault is nil. It never should be, and if it is alert
-		// the developer that made the change as soon as possible.
-		limits = s.setDefault(limits)
-	}
-	return limits
-}
 
 // newSpanLimits returns new span limits that use Splunk defaults (the link
 // count is limited to 1000, the attribute value length is limited to 12000,
@@ -145,7 +54,23 @@ func newSpanLimits() *trace.SpanLimits {
 	// limits will use OTel defaults or the applicable environment variable if
 	// they are set. The Splunk defaults need to be applied only if the
 	// environment variables were unset.
-	limits = sources.applyDefaults(limits)
+	limits.AttributeValueLengthLimit = limitValue(limits.AttributeValueLengthLimit, spanAttributeValueLengthDefault, attributeValueLengthKey, spanAttributeValueLengthKey)
+	limits.AttributeCountLimit = limitValue(limits.AttributeCountLimit, spanAttributeCountDefault, attributeCountKey, spanAttributeCountKey)
+	limits.EventCountLimit = limitValue(limits.EventCountLimit, spanEventCountDefault, spanEventCountKey)
+	limits.LinkCountLimit = limitValue(limits.LinkCountLimit, spanLinkCountDefault, spanLinkCountKey)
+	limits.AttributePerEventCountLimit = limitValue(limits.AttributePerEventCountLimit, spanEventAttributeCountDefault, spanEventAttributeCountKey)
+	limits.AttributePerLinkCountLimit = limitValue(limits.AttributePerLinkCountLimit, spanLinkAttributeCountDefault, spanLinkAttributeCountKey)
 
 	return &limits
+}
+
+// limitValue returns the current limit value if it was set because one of
+// envs is defined, otherwise it returns the limit zero value.
+func limitValue(current, zero int, envs ...string) int {
+	for _, env := range envs {
+		if _, ok := os.LookupEnv(env); ok {
+			return current
+		}
+	}
+	return zero
 }

--- a/distro/limits.go
+++ b/distro/limits.go
@@ -20,14 +20,22 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
+const (
+	attributeValueLengthKey     = "OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT"
+	attributeCountKey           = "OTEL_ATTRIBUTE_COUNT_LIMIT"
+	spanAttributeValueLengthKey = "OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT"
+	spanAttributeCountKey       = "OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT"
+	spanEventCountKey           = "OTEL_SPAN_EVENT_COUNT_LIMIT"
+	spanEventAttributeCountKey  = "OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT"
+	spanLinkCountKey            = "OTEL_SPAN_LINK_COUNT_LIMIT"
+	spanLinkAttributeCountKey   = "OTEL_LINK_ATTRIBUTE_COUNT_LIMIT"
+)
+
 // sources are span limit sources with Splunk defaults.
 var sources = spanLimitSources{
 	// Maximum allowed attribute value size for a span.
 	{
-		envs: []string{
-			"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
-			"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT",
-		},
+		envs: []string{attributeValueLengthKey, spanAttributeValueLengthKey},
 		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
 			limits.AttributeValueLengthLimit = 12000
 			return limits
@@ -36,10 +44,7 @@ var sources = spanLimitSources{
 
 	// Maximum allowed attribute count for a span.
 	{
-		envs: []string{
-			"OTEL_ATTRIBUTE_COUNT_LIMIT",
-			"OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT",
-		},
+		envs: []string{attributeCountKey, spanAttributeCountKey},
 		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
 			// Unlimited.
 			limits.AttributeCountLimit = -1
@@ -49,7 +54,7 @@ var sources = spanLimitSources{
 
 	// Maximum allowed span event count.
 	{
-		envs: []string{"OTEL_SPAN_EVENT_COUNT_LIMIT"},
+		envs: []string{spanEventCountKey},
 		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
 			// Unlimited.
 			limits.EventCountLimit = -1
@@ -59,7 +64,7 @@ var sources = spanLimitSources{
 
 	// Maximum allowed attributes per span event.
 	{
-		envs: []string{"OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT"},
+		envs: []string{spanEventAttributeCountKey},
 		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
 			// Unlimited.
 			limits.AttributePerEventCountLimit = -1
@@ -69,7 +74,7 @@ var sources = spanLimitSources{
 
 	// Maximum allowed span link count.
 	{
-		envs: []string{"OTEL_SPAN_LINK_COUNT_LIMIT"},
+		envs: []string{spanLinkCountKey},
 		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
 			limits.LinkCountLimit = 1000
 			return limits
@@ -78,7 +83,7 @@ var sources = spanLimitSources{
 
 	// Maximum allowed attributes per span link.
 	{
-		envs: []string{"OTEL_LINK_ATTRIBUTE_COUNT_LIMIT"},
+		envs: []string{spanLinkAttributeCountKey},
 		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
 			// Unlimited.
 			limits.AttributePerLinkCountLimit = -1
@@ -133,7 +138,7 @@ func (s spanLimitSource) applyDefault(limits trace.SpanLimits) trace.SpanLimits 
 // count is limited to 1000, the attribute value length is limited to 12000,
 // and all other limts are set to be unlimited) or the corresponding OTel
 // environment variable value if it is set.
-func newSpanLimits() trace.SpanLimits {
+func newSpanLimits() *trace.SpanLimits {
 	// Use trace.NewSpanLimits here to ensure any future additions are not set
 	// to zero, which would happen if we delared with &trace.SpanLimits{...}.
 	limits := trace.NewSpanLimits()
@@ -141,5 +146,7 @@ func newSpanLimits() trace.SpanLimits {
 	// limits will use OTel defaults or the applicable environment variable if
 	// they are set. The Splunk defaults need to be applied only if the
 	// environment variables were unset.
-	return sources.applyDefaults(limits)
+	limits = sources.applyDefaults(limits)
+
+	return &limits
 }

--- a/distro/limits.go
+++ b/distro/limits.go
@@ -1,0 +1,145 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distro
+
+import (
+	"os"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+// sources are span limit sources with Splunk defaults.
+var sources = spanLimitSources{
+	// Maximum allowed attribute value size for a span.
+	{
+		envs: []string{
+			"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+			"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+		},
+		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
+			limits.AttributeValueLengthLimit = 12000
+			return limits
+		},
+	},
+
+	// Maximum allowed attribute count for a span.
+	{
+		envs: []string{
+			"OTEL_ATTRIBUTE_COUNT_LIMIT",
+			"OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT",
+		},
+		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
+			// Unlimited.
+			limits.AttributeCountLimit = -1
+			return limits
+		},
+	},
+
+	// Maximum allowed span event count.
+	{
+		envs: []string{"OTEL_SPAN_EVENT_COUNT_LIMIT"},
+		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
+			// Unlimited.
+			limits.EventCountLimit = -1
+			return limits
+		},
+	},
+
+	// Maximum allowed attributes per span event.
+	{
+		envs: []string{"OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT"},
+		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
+			// Unlimited.
+			limits.AttributePerEventCountLimit = -1
+			return limits
+		},
+	},
+
+	// Maximum allowed span link count.
+	{
+		envs: []string{"OTEL_SPAN_LINK_COUNT_LIMIT"},
+		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
+			limits.LinkCountLimit = 1000
+			return limits
+		},
+	},
+
+	// Maximum allowed attributes per span link.
+	{
+		envs: []string{"OTEL_LINK_ATTRIBUTE_COUNT_LIMIT"},
+		setDefault: func(limits trace.SpanLimits) trace.SpanLimits {
+			// Unlimited.
+			limits.AttributePerLinkCountLimit = -1
+			return limits
+		},
+	},
+}
+
+// spanLimitSources is a collection of all the sources of configuration for
+// a group of spans limits.
+type spanLimitSources []spanLimitSource
+
+// applyDefaults will apply the defaults to all limits that do not have the
+// associated limit's environment variables set.
+func (s spanLimitSources) applyDefaults(limits trace.SpanLimits) trace.SpanLimits {
+	for _, source := range s {
+		limits = source.applyDefault(limits)
+	}
+	return limits
+}
+
+// spanLimitSource are all the sources a span limit is configured from and the
+// default value used if none of those sources are used.
+type spanLimitSource struct {
+	envs       []string
+	setDefault func(limits trace.SpanLimits) trace.SpanLimits
+}
+
+// envsSet returns if any environment variable for s is set.
+func (s spanLimitSource) envsSet() bool {
+	for _, env := range s.envs {
+		if _, ok := os.LookupEnv(env); ok {
+			return true
+		}
+	}
+	return false
+
+}
+
+// applyDefaults will apply the default to the corresponding limit in limits
+// if the associated environment variables are not set.
+func (s spanLimitSource) applyDefault(limits trace.SpanLimits) trace.SpanLimits {
+	if !s.envsSet() {
+		// Panic if setDefault is nil. It never should be, and if it is alert
+		// the developer that made the change as soon as possible.
+		limits = s.setDefault(limits)
+	}
+	return limits
+}
+
+// newSpanLimits returns new span limits that use Splunk defaults (the link
+// count is limited to 1000, the attribute value length is limited to 12000,
+// and all other limts are set to be unlimited) or the corresponding OTel
+// environment variable value if it is set.
+func newSpanLimits() trace.SpanLimits {
+	// Use trace.NewSpanLimits here to ensure any future additions are not set
+	// to zero, which would happen if we delared with &trace.SpanLimits{...}.
+	limits := trace.NewSpanLimits()
+
+	// limits will use OTel defaults or the applicable environment variable if
+	// they are set. The Splunk defaults need to be applied only if the
+	// environment variables were unset.
+	return sources.applyDefaults(limits)
+}

--- a/distro/limits_test.go
+++ b/distro/limits_test.go
@@ -21,7 +21,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
-func expected(aLen, aN, eN, lN, aPerE, aPerL int) *trace.SpanLimits {
+func expectedSL(aLen, aN, eN, lN, aPerE, aPerL int) *trace.SpanLimits {
 	return &trace.SpanLimits{
 		AttributeValueLengthLimit:   aLen,
 		AttributeCountLimit:         aN,
@@ -40,63 +40,63 @@ func TestNewSpanLimits(t *testing.T) {
 	}{
 		{
 			name: "defaults",
-			want: expected(12000, -1, -1, 1000, -1, -1),
+			want: expectedSL(12000, -1, -1, 1000, -1, -1),
 		},
 		{
 			name: attributeValueLengthKey,
 			envs: map[string]string{
 				attributeValueLengthKey: "10",
 			},
-			want: expected(10, -1, -1, 1000, -1, -1),
+			want: expectedSL(10, -1, -1, 1000, -1, -1),
 		},
 		{
 			name: spanAttributeValueLengthKey,
 			envs: map[string]string{
 				spanAttributeValueLengthKey: "10",
 			},
-			want: expected(10, -1, -1, 1000, -1, -1),
+			want: expectedSL(10, -1, -1, 1000, -1, -1),
 		},
 		{
 			name: attributeCountKey,
 			envs: map[string]string{
 				attributeCountKey: "10",
 			},
-			want: expected(12000, 10, -1, 1000, -1, -1),
+			want: expectedSL(12000, 10, -1, 1000, -1, -1),
 		},
 		{
 			name: spanAttributeCountKey,
 			envs: map[string]string{
 				spanAttributeCountKey: "10",
 			},
-			want: expected(12000, 10, -1, 1000, -1, -1),
+			want: expectedSL(12000, 10, -1, 1000, -1, -1),
 		},
 		{
 			name: spanEventCountKey,
 			envs: map[string]string{
 				spanEventCountKey: "10",
 			},
-			want: expected(12000, -1, 10, 1000, -1, -1),
+			want: expectedSL(12000, -1, 10, 1000, -1, -1),
 		},
 		{
 			name: spanEventAttributeCountKey,
 			envs: map[string]string{
 				spanEventAttributeCountKey: "10",
 			},
-			want: expected(12000, -1, -1, 1000, 10, -1),
+			want: expectedSL(12000, -1, -1, 1000, 10, -1),
 		},
 		{
 			name: spanLinkCountKey,
 			envs: map[string]string{
 				spanLinkCountKey: "10",
 			},
-			want: expected(12000, -1, -1, 10, -1, -1),
+			want: expectedSL(12000, -1, -1, 10, -1, -1),
 		},
 		{
 			name: spanLinkAttributeCountKey,
 			envs: map[string]string{
 				spanLinkAttributeCountKey: "10",
 			},
-			want: expected(12000, -1, -1, 1000, -1, 10),
+			want: expectedSL(12000, -1, -1, 1000, -1, 10),
 		},
 	}
 

--- a/distro/limits_test.go
+++ b/distro/limits_test.go
@@ -1,0 +1,111 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distro
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+func expected(aLen, aN, eN, lN, aPerE, aPerL int) *trace.SpanLimits {
+	return &trace.SpanLimits{
+		AttributeValueLengthLimit:   aLen,
+		AttributeCountLimit:         aN,
+		EventCountLimit:             eN,
+		LinkCountLimit:              lN,
+		AttributePerEventCountLimit: aPerE,
+		AttributePerLinkCountLimit:  aPerL,
+	}
+}
+
+func TestNewSpanLimits(t *testing.T) {
+	tests := []struct {
+		name string
+		envs map[string]string
+		want *trace.SpanLimits
+	}{
+		{
+			name: "defaults",
+			want: expected(12000, -1, -1, 1000, -1, -1),
+		},
+		{
+			name: attributeValueLengthKey,
+			envs: map[string]string{
+				attributeValueLengthKey: "10",
+			},
+			want: expected(10, -1, -1, 1000, -1, -1),
+		},
+		{
+			name: spanAttributeValueLengthKey,
+			envs: map[string]string{
+				spanAttributeValueLengthKey: "10",
+			},
+			want: expected(10, -1, -1, 1000, -1, -1),
+		},
+		{
+			name: attributeCountKey,
+			envs: map[string]string{
+				attributeCountKey: "10",
+			},
+			want: expected(12000, 10, -1, 1000, -1, -1),
+		},
+		{
+			name: spanAttributeCountKey,
+			envs: map[string]string{
+				spanAttributeCountKey: "10",
+			},
+			want: expected(12000, 10, -1, 1000, -1, -1),
+		},
+		{
+			name: spanEventCountKey,
+			envs: map[string]string{
+				spanEventCountKey: "10",
+			},
+			want: expected(12000, -1, 10, 1000, -1, -1),
+		},
+		{
+			name: spanEventAttributeCountKey,
+			envs: map[string]string{
+				spanEventAttributeCountKey: "10",
+			},
+			want: expected(12000, -1, -1, 1000, 10, -1),
+		},
+		{
+			name: spanLinkCountKey,
+			envs: map[string]string{
+				spanLinkCountKey: "10",
+			},
+			want: expected(12000, -1, -1, 10, -1, -1),
+		},
+		{
+			name: spanLinkAttributeCountKey,
+			envs: map[string]string{
+				spanLinkAttributeCountKey: "10",
+			},
+			want: expected(12000, -1, -1, 1000, -1, 10),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for key, val := range test.envs {
+				t.Cleanup(Setenv(key, val))
+			}
+			assert.Equal(t, test.want, newSpanLimits())
+		})
+	}
+}

--- a/distro/otel.go
+++ b/distro/otel.go
@@ -103,6 +103,7 @@ func Run(opts ...Option) (SDK, error) {
 	traceProvider := trace.NewTracerProvider(
 		trace.WithResource(res),
 		trace.WithSampler(trace.AlwaysSample()),
+		trace.WithRawSpanLimits(c.SpanLimits),
 		trace.WithSpanProcessor(trace.NewBatchSpanProcessor(exp)),
 	)
 	otel.SetTracerProvider(traceProvider)

--- a/distro/otel.go
+++ b/distro/otel.go
@@ -103,7 +103,7 @@ func Run(opts ...Option) (SDK, error) {
 	traceProvider := trace.NewTracerProvider(
 		trace.WithResource(res),
 		trace.WithSampler(trace.AlwaysSample()),
-		trace.WithRawSpanLimits(c.SpanLimits),
+		trace.WithRawSpanLimits(*c.SpanLimits),
 		trace.WithSpanProcessor(trace.NewBatchSpanProcessor(exp)),
 	)
 	otel.SetTracerProvider(traceProvider)


### PR DESCRIPTION
Conform with the [GDI specification](https://github.com/signalfx/gdi-specification/blob/33f1b65633c5f83acc1622bbc79f498e513a6c7c/specification/configuration.md#instrumentation-libraries):

- Distribution MUST default to 1000 for OTEL_SPAN_LINK_COUNT_LIMIT (not OpenTelemetry default)
- Distribution MUST default to 12000 for OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT (not OpenTelemetry default)
- Distribution MUST be unset "" (unlimited) for all others (not OpenTelemetry default)