### PR TITLE
Fix OTLP endpoint when using SPLUNK_REALM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Use the correct Splunk Observabilty Cloud OTLP over gRPC endpoint
+  when `SPLUNK_REALM` is set. (#791)
+
 ## [0.8.0] - 2022-04-05
 
 ### Added

--- a/distro/config.go
+++ b/distro/config.go
@@ -66,7 +66,7 @@ const (
 	defaultJaegerEndpoint = "http://127.0.0.1:9080/v1/trace"
 
 	realmEndpointFormat     = "https://ingest.%s.signalfx.com/v2/trace"
-	otlpRealmEndpointFormat = realmEndpointFormat + "/otlp"
+	otlpRealmEndpointFormat = "ingest.%s.signalfx.com:443"
 )
 
 type exporterConfig struct {

--- a/distro/exporter.go
+++ b/distro/exporter.go
@@ -49,8 +49,7 @@ func newOTLPExporter(c *exporterConfig) (trace.SpanExporter, error) {
 	if c.TLSConfig != nil {
 		tlsCreds := credentials.NewTLS(c.TLSConfig)
 		opts = append(opts, otlptracegrpc.WithTLSCredentials(tlsCreds))
-	} else if realm, ok := os.LookupEnv(splunkRealmKey); !ok || none(realm) {
-		// use insecure gRPC when SPLUNK_REALM is not set
+	} else {
 		opts = append(opts, otlptracegrpc.WithInsecure())
 	}
 
@@ -77,7 +76,7 @@ func otlpEndpoint(configured string) string {
 	}
 
 	// Use the realm only if OTEL_EXPORTER_OTLP*_ENDPOINT are not defined.
-	if realm, ok := os.LookupEnv(splunkRealmKey); ok && !none(realm) {
+	if realm, ok := os.LookupEnv(splunkRealmKey); ok && notNone(realm) {
 		return fmt.Sprintf(otlpRealmEndpointFormat, realm)
 	}
 
@@ -123,7 +122,7 @@ func jaegerEndpoint(configured string) string {
 	}
 
 	// Use the realm only if OTEL_EXPORTER_JAGER_ENDPOINT is not defined.
-	if realm, ok := os.LookupEnv(splunkRealmKey); ok && !none(realm) {
+	if realm, ok := os.LookupEnv(splunkRealmKey); ok && notNone(realm) {
 		return fmt.Sprintf(realmEndpointFormat, realm)
 	}
 
@@ -131,7 +130,7 @@ func jaegerEndpoint(configured string) string {
 	return defaultJaegerEndpoint
 }
 
-// none returns if s is empty or set to none.
-func none(s string) bool {
-	return s == "" || s == "none"
+// notNone returns if s is not empty or set to none.
+func notNone(s string) bool {
+	return s != "" && s != "none"
 }


### PR DESCRIPTION
## Why

The spans were not being exported when `SPLUNK_ACCESS_TOKEN=<access_token> SPLUNK_REALM=<realm>` env vars were set.

Reference: https://docs.splunk.com/Observability/gdi/get-data-in/application/go/instrumentation/instrument-go-application.html#send-data-directly-to-observability-cloud  (this does not work)

## What

Use the correct Splunk Observabilty Cloud OTLP over gRPC endpoint when `SPLUNK_REALM` is set.