### PR TITLE
Simplify example

### DIFF
--- a/example/go.mod
+++ b/example/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp v0.8.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.32.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.32.0
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 
 replace github.com/signalfx/splunk-otel-go/distro => ../distro

--- a/example/go.sum
+++ b/example/go.sum
@@ -301,7 +301,6 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
## Why

The existing (before changes) example runs HTTP calls in a loop and SIGINT (CTRL+C) must be provided to stop the program. It is inconvenient during testing when it is enough to test a single call. 


## What

Change the program to emit a single trace instead of creating a trace every 10 seconds.

After the changes, the developer can run a little script like

```sh
go run .
SPLUNK_REALM=us1 go run .
OTEL_TRACES_EXPORTER=jaeger-thrift-splunk SPLUNK_REALM=us0 go run .
OTEL_TRACES_EXPORTER=jaeger-thrift-splunk OTEL_EXPORTER_JAEGER_ENDPOINT=http://localhost:14268/api/traces go run .
```

go for a coffee and after a few minutes check if everything was sent to O11y Cloud as expected.

PS. The [demo example](https://github.com/signalfx/tracing-examples/tree/main/opentelemetry-tracing/opentelemetry-go/gorilla-mux) still has a loop which I find more adequate.