### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ and `go.opentelemetry.io/contrib*` dependencies are updated to [`v1.7.0`/`v0.32.
 
 ### Fixed
 
-- Use the correct Splunk Observabilty Cloud OTLP over gRPC endpoint
+- Use the correct Splunk Observability Cloud OTLP over gRPC endpoint
   when `SPLUNK_REALM` is set. (#791)
 
 ## [0.8.0] - 2022-04-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.9.0] - 2022-05-26
+
+This release contains configuration fixes and simplifies the API before
+a stable release is published.
+
+`go.opentelemetry.io/otel*` dependencies are updated to [`v1.7.0`][otel-v1.7.0]
+and `go.opentelemetry.io/contrib*` dependencies are updated to [`v1.7.0`/`v0.32.0`][contrib-v1.7.0].
+
 ### Changed
 
 - The `NewTracer` function from
@@ -34,6 +42,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove `opts ...Option` parameter from `NewHandler` function
   from `github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp`
   package. (#947)
+- Update `go.opentelemetry.io/otel*` dependencies from [`v1.6.1`][otel-v1.6.1]
+  to [`v1.7.0`][otel-v1.7.0]. (#926)
+- Update `go.opentelemetry.io/contrib*` dependencies from
+  [`v1.6.0`/`v0.31.0`][contrib-v1.6.0] to [`v1.7.0`/`v0.32.0`][contrib-v1.7.0].
+  (#926)
   
 ### Removed
 
@@ -270,7 +283,8 @@ an impedance mismatch with this duplicate batching.
 - Add [`splunkhttp`](./instrumentation/net/http/splunkhttp) module providing
   additional Splunk specific instrumentation for `net/http`.
 
-[Unreleased]: https://github.com/signalfx/splunk-otel-go/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/signalfx/splunk-otel-go/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.9.0
 [0.8.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.8.0
 [0.7.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.7.0
 [0.6.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.6.0
@@ -279,6 +293,7 @@ an impedance mismatch with this duplicate batching.
 [0.2.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.2.0
 [0.1.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.1.0
 
+[otel-v1.7.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.7.0
 [otel-v1.6.1]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.6.1
 [otel-v1.6.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.6.0
 [otel-v1.3.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.3.0
@@ -288,6 +303,7 @@ an impedance mismatch with this duplicate batching.
 [otel-v0.20.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.20.0
 [otel-v0.19.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.19.0
 
+[contrib-v1.7.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.7.0
 [contrib-v1.6.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.6.0
 [contrib-v1.3.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.3.0
 [contrib-v0.28.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.28.0

--- a/distro/go.mod
+++ b/distro/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
-	github.com/signalfx/splunk-otel-go v0.8.0
+	github.com/signalfx/splunk-otel-go v0.9.0
 	github.com/stretchr/testify v1.7.1
 	github.com/tonglil/buflogr v0.0.0-20220114010534-d490b3990d7e
 	go.opentelemetry.io/contrib/propagators/aws v1.7.0

--- a/example/go.mod
+++ b/example/go.mod
@@ -4,11 +4,13 @@ go 1.16
 
 require (
 	github.com/gorilla/mux v1.8.0
-	github.com/signalfx/splunk-otel-go/distro v0.8.0
-	github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp v0.8.0
+	github.com/signalfx/splunk-otel-go/distro v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp v0.9.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.32.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.32.0
 )
+
+replace github.com/signalfx/splunk-otel-go => ../
 
 replace github.com/signalfx/splunk-otel-go/distro => ../distro
 

--- a/example/go.sum
+++ b/example/go.sum
@@ -157,8 +157,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/signalfx/splunk-otel-go v0.8.0 h1:oPTfWh1HqheX/xB1TwR5BmCXp7TH9xg7PJb9z5Xahco=
-github.com/signalfx/splunk-otel-go v0.8.0/go.mod h1:aQ3JRbqt9+mT1NfpzkZp8OEspooRZC35XmUfiSfoooU=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/instrumentation/database/sql/splunksql/go.mod
+++ b/instrumentation/database/sql/splunksql/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0

--- a/instrumentation/database/sql/splunksql/test/go.mod
+++ b/instrumentation/database/sql/splunksql/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/confluentinc/confluent-kafka-go v1.8.2
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/confluentinc/confluent-kafka-go v1.8.2
 	github.com/ory/dockertest/v3 v3.9.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/github.com/go-chi/chi/splunkchi/go.mod
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/go-chi/chi v1.5.4
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0
 )

--- a/instrumentation/github.com/go-chi/chi/splunkchi/test/go.mod
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/go-chi/chi v1.5.4
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/go.mod
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/go-sql-driver/mysql v1.6.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
 	github.com/stretchr/testify v1.7.1
 )
 

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/go.mod
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/go.mod
@@ -4,8 +4,8 @@ go 1.16
 
 require (
 	github.com/ory/dockertest/v3 v3.9.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.8.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/go.mod
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/gomodule/redigo v1.8.8
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/go.mod
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.0.3 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/go.mod
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/graph-gophers/graphql-go v1.4.0
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0
 )

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test/go.mod
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/graph-gophers/graphql-go v1.4.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel/sdk v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/go.mod
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/jackc/pgx/v4 v4.16.1
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
 	github.com/stretchr/testify v1.7.1
 )
 

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/test/go.mod
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/test/go.mod
@@ -4,8 +4,8 @@ go 1.16
 
 require (
 	github.com/ory/dockertest/v3 v3.9.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.8.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/github.com/jinzhu/gorm/splunkgorm/go.mod
+++ b/instrumentation/github.com/jinzhu/gorm/splunkgorm/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/jinzhu/gorm v1.9.16
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
 	github.com/stretchr/testify v1.7.1
 )
 

--- a/instrumentation/github.com/jmoiron/sqlx/splunksqlx/go.mod
+++ b/instrumentation/github.com/jmoiron/sqlx/splunksqlx/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/jmoiron/sqlx v1.3.5
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
 	github.com/stretchr/testify v1.7.1
 )
 

--- a/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/go.mod
+++ b/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/go.mod
@@ -6,5 +6,3 @@ require (
 	github.com/julienschmidt/httprouter v1.3.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.32.0
 )
-
-replace github.com/signalfx/splunk-otel-go => ../../../../..

--- a/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test/go.mod
+++ b/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.32.0
 	go.opentelemetry.io/otel v1.7.0

--- a/instrumentation/github.com/lib/pq/splunkpq/go.mod
+++ b/instrumentation/github.com/lib/pq/splunkpq/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/lib/pq v1.10.6
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
 	github.com/stretchr/testify v1.7.1
 )
 

--- a/instrumentation/github.com/lib/pq/splunkpq/test/go.mod
+++ b/instrumentation/github.com/lib/pq/splunkpq/test/go.mod
@@ -11,8 +11,8 @@ replace (
 
 require (
 	github.com/ory/dockertest/v3 v3.9.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.8.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/github.com/miekg/dns/splunkdns/go.mod
+++ b/instrumentation/github.com/miekg/dns/splunkdns/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/miekg/dns v1.1.49
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0
 )

--- a/instrumentation/github.com/miekg/dns/splunkdns/test/go.mod
+++ b/instrumentation/github.com/miekg/dns/splunkdns/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/miekg/dns v1.1.49
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/go.mod
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/gole
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
 	github.com/stretchr/testify v1.7.1
 	github.com/syndtr/goleveldb v1.0.0
 	go.opentelemetry.io/otel v1.7.0

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/go.mod
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/gole
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb v0.9.0
 	github.com/stretchr/testify v1.7.1
 	github.com/syndtr/goleveldb v1.0.0
 	go.opentelemetry.io/otel v1.7.0

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/go.mod
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/bun
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
 	github.com/stretchr/testify v1.7.1
 	github.com/tidwall/buntdb v1.2.9
 	go.opentelemetry.io/otel v1.7.0

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/go.mod
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/bun
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb v0.9.0
 	github.com/stretchr/testify v1.7.1
 	github.com/tidwall/buntdb v1.2.9
 	go.opentelemetry.io/otel v1.7.0

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/go.mod
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/olivere/elastic/v7 v7.0.32
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/go.mod
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.0.3 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/internal/go.mod
+++ b/instrumentation/internal/go.mod
@@ -2,11 +2,11 @@ module github.com/signalfx/splunk-otel-go/instrumentation/internal
 
 go 1.16
 
-replace github.com/signalfx/splunk-otel-go => ../../
-
 require (
-	github.com/signalfx/splunk-otel-go v0.8.0
+	github.com/signalfx/splunk-otel-go v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0
 )
+
+replace github.com/signalfx/splunk-otel-go => ../../

--- a/instrumentation/k8s.io/client-go/splunkclient-go/go.mod
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splun
 go 1.17
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0
@@ -32,7 +32,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go v0.8.0 // indirect
+	github.com/signalfx/splunk-otel-go v0.9.0 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/go.mod
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splun
 go 1.17
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go v0.8.0
+	github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go v0.9.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0
@@ -16,8 +16,8 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go v0.8.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.8.0 // indirect
+	github.com/signalfx/splunk-otel-go v0.9.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect

--- a/version.go
+++ b/version.go
@@ -20,5 +20,5 @@ package splunkotel // import "github.com/signalfx/splunk-otel-go"
 
 // Version is the current release version of splunk-otel-go in use.
 func Version() string {
-	return "0.8.0"
+	return "0.9.0"
 }


### PR DESCRIPTION
This release contains configuration fixes and simplifies the API before
a stable release is published.

`go.opentelemetry.io/otel*` dependencies are updated to [`v1.7.0`][otel-v1.7.0]
and `go.opentelemetry.io/contrib*` dependencies are updated to [`v1.7.0`/`v0.32.0`][contrib-v1.7.0].

### Changed

- The `NewTracer` function from
  `github.com/signalfx/splunk-otel-go/instrumentation/github.com/graphql-gophers/graphql-go/splunkgraphql`
  now returns a `tracer.Tracer` instead of the deprecated `trace.Tracer` from
  `github.com/graph-gophers/graphql-go`. (#855)
- The `TraceQuery` method of the `Tracer` from
  `github.com/signalfx/splunk-otel-go/instrumentation/github.com/graphql-gophers/graphql-go/splunkgraphql`
  now returns a `tracer.QueryFinishFunc` instead of the deprecated
  `trace.TraceQueryFinishFunc` from `github.com/graph-gophers/graphql-go`.
  (#855)
- The `TraceField` method of the `Tracer` from
  `github.com/signalfx/splunk-otel-go/instrumentation/github.com/graphql-gophers/graphql-go/splunkgraphql`
  now returns a `tracer.FieldFinishFunc` instead of the deprecated
  `trace.TraceFieldFinishFunc` from `github.com/graph-gophers/graphql-go`.
  (#855)
- The `TraceValidation` method of the `Tracer` from
  `github.com/signalfx/splunk-otel-go/instrumentation/github.com/graphql-gophers/graphql-go/splunkgraphql`
  now returns a `tracer.ValidationFinishFunc` instead of the deprecated
  `trace.TraceValidationFinishFunc` from `github.com/graph-gophers/graphql-go`.
  (#855)
- Configure TLS using the system CA for OTLP gRPC exporter connections when
  configured to connect to external endpoints. (#792)
- Remove `opts ...Option` parameter from `NewHandler` function
  from `github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp`
  package. (#947)
- Update `go.opentelemetry.io/otel*` dependencies from [`v1.6.1`][otel-v1.6.1]
  to [`v1.7.0`][otel-v1.7.0]. (#926)
- Update `go.opentelemetry.io/contrib*` dependencies from
  [`v1.6.0`/`v0.31.0`][contrib-v1.6.0] to [`v1.7.0`/`v0.32.0`][contrib-v1.7.0].
  (#926)
  
### Removed

- Minimize `github.com/signalfx/splunk-otel-go/distro` package to
  contain only necessary option functions. (#941)
  - Remove `WithAccessToken` function,
    use `SPLUNK_ACCESS_TOKEN` environment variable instead.
  - Remove `WithEndpoint` function,
    use one of the
    `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_JAEGER_ENDPOINT`
    environment variables instead.
  - Remove `WithPropagator` function,
    use `OTEL_PROPAGATORS` environment variable instead.
  - Remove `WithTraceExporter` function,
    use `OTEL_TRACES_EXPORTER` environment variable instead.
- Minimize `github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp`
  package to contain only necessary functions and types. (#947)
  - Remove `WithTraceResponseHeader` function,
    use `SPLUNK_TRACE_RESPONSE_HEADER_ENABLED` environment variable instead.
  - Remove `TraceResponseHeaderMiddleware` function,
    use `NewHandler` function instead.
  - Remove `Option` type.

### Fixed

- Use the correct Splunk Observability Cloud OTLP over gRPC endpoint
  when `SPLUNK_REALM` is set. (#791)

[otel-v1.7.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.7.0
[otel-v1.6.1]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.6.1

[contrib-v1.7.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.7.0
[contrib-v1.6.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.6.0