### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ This is the first stable release of the Splunk Distribution of OpenTelemetry Go
 which is compliant with [Splunk's GDI Specification v1.3.0](https://github.com/signalfx/gdi-specification/tree/v1.3.0).
 
 Please note that although the distribution is marked as stable,
-some of its dependant components (e.g. `otelhttp` instrumentation library)
+some of its dependent components (e.g. `otelhttp` instrumentation library)
 are still experimental.
 
-This release uses [`OpenTelemetry Go v1.7.0`][otel-v1.7.0] and
-[`OpenTelemetry Go Contrib v1.7.0`/`v0.32.0`][contrib-v1.7.0].
+This release uses [OpenTelemetry Go v1.7.0][otel-v1.7.0] and
+[OpenTelemetry Go Contrib v1.7.0/v0.32.0][contrib-v1.7.0].
 
 ## [0.9.0] - 2022-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.0.0] - 2022-06-09
+
+This is the first stable release of the Splunk Distribution of OpenTelemetry Go
+which is compliant with [Splunk's GDI Specification v1.3.0](https://github.com/signalfx/gdi-specification/tree/v1.3.0).
+
+Please note that although the distribution is marked as stable,
+some of its dependant components (e.g. `otelhttp` instrumentation library)
+are still experimental.
+
+This release uses [`OpenTelemetry Go v1.7.0`][otel-v1.7.0] and
+[`OpenTelemetry Go Contrib v1.7.0`/`v0.32.0`][contrib-v1.7.0].
+
 ## [0.9.0] - 2022-05-26
 
 This release contains configuration fixes and simplifies the API before
@@ -283,7 +295,8 @@ an impedance mismatch with this duplicate batching.
 - Add [`splunkhttp`](./instrumentation/net/http/splunkhttp) module providing
   additional Splunk specific instrumentation for `net/http`.
 
-[Unreleased]: https://github.com/signalfx/splunk-otel-go/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/signalfx/splunk-otel-go/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v1.0.0
 [0.9.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.9.0
 [0.8.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.8.0
 [0.7.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.7.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![GitHub Release](https://img.shields.io/github/v/release/signalfx/splunk-otel-go?include_prereleases)](https://github.com/signalfx/splunk-otel-go/releases)
 [![Go Reference](https://pkg.go.dev/badge/github.com/signalfx/splunk-otel-go.svg)](https://pkg.go.dev/github.com/signalfx/splunk-otel-go)
 [![go.mod](https://img.shields.io/github/go-mod/go-version/signalfx/splunk-otel-go)](go.mod)
+[![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-%23E05735)](CHANGELOG.md)
 [![LICENSE](https://img.shields.io/github/license/signalfx/splunk-otel-go)](LICENSE)
+
 [![Build Status](https://img.shields.io/github/workflow/status/signalfx/splunk-otel-go/ci)](https://github.com/signalfx/splunk-otel-go/actions?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/signalfx/splunk-otel-go/branch/main/graph/badge.svg)](https://codecov.io/gh/signalfx/splunk-otel-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/signalfx/splunk-otel-go)](https://goreportcard.com/report/github.com/signalfx/splunk-otel-go)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Explore how to get started with the project [here](./docs/README.md#getting-star
 For troubleshooting information, see the
 [Troubleshooting](./docs/troubleshooting.md) documentation.
 
-### Examples
+## Examples
 
 You can find our official "user-facing" examples
 [here](https://github.com/signalfx/tracing-examples/tree/main/opentelemetry-tracing/opentelemetry-go).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Splunk Distribution of OpenTelemetry Go
 
+[![OpenTelemetry Go](https://img.shields.io/badge/OTel-1.7.0-blueviolet)](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.7.0)
 [![Splunk GDI Specification](https://img.shields.io/badge/GDI-1.3.0-blueviolet)](https://github.com/signalfx/gdi-specification/releases/tag/v1.3.0)
 [![GitHub Release](https://img.shields.io/github/v/release/signalfx/splunk-otel-go?include_prereleases)](https://github.com/signalfx/splunk-otel-go/releases)
 [![Go Reference](https://pkg.go.dev/badge/github.com/signalfx/splunk-otel-go.svg)](https://pkg.go.dev/github.com/signalfx/splunk-otel-go)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Splunk Distribution of OpenTelemetry Go
 
-[![Splunk GDI Specification](https://img.shields.io/badge/GDI-1.2.0-blue)](https://github.com/signalfx/gdi-specification/releases/tag/v1.2.0)
+[![Splunk GDI Specification](https://img.shields.io/badge/GDI-1.3.0-blueviolet)](https://github.com/signalfx/gdi-specification/releases/tag/v1.3.0)
 [![GitHub Release](https://img.shields.io/github/v/release/signalfx/splunk-otel-go?include_prereleases)](https://github.com/signalfx/splunk-otel-go/releases)
 [![Go Reference](https://pkg.go.dev/badge/github.com/signalfx/splunk-otel-go.svg)](https://pkg.go.dev/github.com/signalfx/splunk-otel-go)
 [![go.mod](https://img.shields.io/github/go-mod/go-version/signalfx/splunk-otel-go)](go.mod)
@@ -13,10 +13,6 @@ The Splunk distribution of [OpenTelemetry
 Go](https://github.com/open-telemetry/opentelemetry-go) provides
 multiple packages that instrument your Go
 application to capture and report distributed traces to Splunk APM.
-
-> :construction: This project is currently in **BETA**.
-> It is **officially supported** by Splunk.
-> However, breaking changes **MAY** be introduced.
 
 ## Documentation
 

--- a/distro/go.mod
+++ b/distro/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
-	github.com/signalfx/splunk-otel-go v0.9.0
+	github.com/signalfx/splunk-otel-go v1.0.0
 	github.com/stretchr/testify v1.7.2
 	github.com/tonglil/buflogr v0.0.0-20220114010534-d490b3990d7e
 	go.opentelemetry.io/contrib/propagators/aws v1.7.0

--- a/example/go.mod
+++ b/example/go.mod
@@ -4,8 +4,8 @@ go 1.16
 
 require (
 	github.com/gorilla/mux v1.8.0
-	github.com/signalfx/splunk-otel-go/distro v0.9.0
-	github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp v0.9.0
+	github.com/signalfx/splunk-otel-go/distro v1.0.0
+	github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp v1.0.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.32.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.32.0
 )

--- a/instrumentation/database/sql/splunksql/go.mod
+++ b/instrumentation/database/sql/splunksql/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0

--- a/instrumentation/database/sql/splunksql/test/go.mod
+++ b/instrumentation/database/sql/splunksql/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/confluentinc/confluent-kafka-go v1.8.2
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/confluentinc/confluent-kafka-go v1.8.2
 	github.com/ory/dockertest/v3 v3.9.1
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/github.com/go-chi/chi/splunkchi/go.mod
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/go-chi/chi v1.5.4
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.0.0
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0
 )

--- a/instrumentation/github.com/go-chi/chi/splunkchi/test/go.mod
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/go-chi/chi v1.5.4
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/go.mod
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/go-sql-driver/mysql v1.6.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.0.0
 	github.com/stretchr/testify v1.7.2
 )
 

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/go.mod
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/go.mod
@@ -4,8 +4,8 @@ go 1.16
 
 require (
 	github.com/ory/dockertest/v3 v3.9.1
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.0.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/go.mod
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/gomodule/redigo v1.8.8
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/go.mod
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.0.3 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/go.mod
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/graph-gophers/graphql-go v1.4.0
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.0.0
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0
 )

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test/go.mod
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/graph-gophers/graphql-go v1.4.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel/sdk v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/go.mod
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/jackc/pgx/v4 v4.16.1
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.0.0
 	github.com/stretchr/testify v1.7.2
 )
 

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/test/go.mod
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/test/go.mod
@@ -4,8 +4,8 @@ go 1.16
 
 require (
 	github.com/ory/dockertest/v3 v3.9.1
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.0.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/github.com/jinzhu/gorm/splunkgorm/go.mod
+++ b/instrumentation/github.com/jinzhu/gorm/splunkgorm/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/jinzhu/gorm v1.9.16
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.0.0
 	github.com/stretchr/testify v1.7.2
 )
 

--- a/instrumentation/github.com/jmoiron/sqlx/splunksqlx/go.mod
+++ b/instrumentation/github.com/jmoiron/sqlx/splunksqlx/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/jmoiron/sqlx v1.3.5
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.0.0
 	github.com/stretchr/testify v1.7.2
 )
 

--- a/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test/go.mod
+++ b/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.32.0
 	go.opentelemetry.io/otel v1.7.0

--- a/instrumentation/github.com/lib/pq/splunkpq/go.mod
+++ b/instrumentation/github.com/lib/pq/splunkpq/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/lib/pq v1.10.6
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.0.0
 	github.com/stretchr/testify v1.7.2
 )
 

--- a/instrumentation/github.com/lib/pq/splunkpq/test/go.mod
+++ b/instrumentation/github.com/lib/pq/splunkpq/test/go.mod
@@ -11,8 +11,8 @@ replace (
 
 require (
 	github.com/ory/dockertest/v3 v3.9.1
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v0.9.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.0.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/github.com/miekg/dns/splunkdns/go.mod
+++ b/instrumentation/github.com/miekg/dns/splunkdns/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/miekg/dns v1.1.49
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.0.0
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0
 )

--- a/instrumentation/github.com/miekg/dns/splunkdns/test/go.mod
+++ b/instrumentation/github.com/miekg/dns/splunkdns/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/miekg/dns v1.1.49
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/go.mod
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/gole
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.0.0
 	github.com/stretchr/testify v1.7.2
 	github.com/syndtr/goleveldb v1.0.0
 	go.opentelemetry.io/otel v1.7.0

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/go.mod
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/gole
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb v1.0.0
 	github.com/stretchr/testify v1.7.2
 	github.com/syndtr/goleveldb v1.0.0
 	go.opentelemetry.io/otel v1.7.0

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/go.mod
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/bun
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.0.0
 	github.com/stretchr/testify v1.7.2
 	github.com/tidwall/buntdb v1.2.9
 	go.opentelemetry.io/otel v1.7.0

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/go.mod
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/bun
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb v1.0.0
 	github.com/stretchr/testify v1.7.2
 	github.com/tidwall/buntdb v1.2.9
 	go.opentelemetry.io/otel v1.7.0

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/go.mod
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/olivere/elastic/v7 v7.0.32
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/go.mod
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.0.3 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0

--- a/instrumentation/internal/go.mod
+++ b/instrumentation/internal/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/internal
 go 1.16
 
 require (
-	github.com/signalfx/splunk-otel-go v0.9.0
+	github.com/signalfx/splunk-otel-go v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0

--- a/instrumentation/k8s.io/client-go/splunkclient-go/go.mod
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splun
 go 1.17
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0
@@ -32,7 +32,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go v0.9.0 // indirect
+	github.com/signalfx/splunk-otel-go v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/go.mod
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splun
 go 1.17
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go v0.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go v1.0.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0
@@ -16,8 +16,8 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go v0.9.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v0.9.0 // indirect
+	github.com/signalfx/splunk-otel-go v1.0.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect

--- a/version.go
+++ b/version.go
@@ -20,5 +20,5 @@ package splunkotel // import "github.com/signalfx/splunk-otel-go"
 
 // Version is the current release version of splunk-otel-go in use.
 func Version() string {
-	return "0.9.0"
+	return "1.0.0"
 }


### PR DESCRIPTION
## Why

https://github.com/signalfx/gdi-specification/issues/173

## What

This is the first stable release of the Splunk Distribution of OpenTelemetry Go
which is compliant with [Splunk's GDI Specification v1.3.0](https://github.com/signalfx/gdi-specification/tree/v1.3.0).

Please note that although the distribution is marked as stable,
some of its dependent components (e.g. `otelhttp` instrumentation library)
are still experimental.

This release uses [OpenTelemetry Go v1.7.0][otel-v1.7.0] and
[OpenTelemetry Go Contrib v1.7.0/v0.32.0][contrib-v1.7.0].

[otel-v1.7.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.7.0
[contrib-v1.7.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.7.0