### PR TITLE
Bump markdownlintcli to v0.32.0

### DIFF
--- a/build/pipeline.go
+++ b/build/pipeline.go
@@ -168,7 +168,7 @@ func taskMarkdownLint(skipDocker goyek.RegisteredBoolParam) goyek.Task {
 				tf.Skip("skipping as Docker is needed")
 			}
 
-			if err := tf.Cmd("docker", "run", "--rm", "-v", WorkDir(tf)+":/workdir", "ghcr.io/igorshubovych/markdownlint-cli:v0.31.1", "**/*.md").Run(); err != nil {
+			if err := tf.Cmd("docker", "run", "--rm", "-v", WorkDir(tf)+":/workdir", "ghcr.io/igorshubovych/markdownlint-cli:v0.32.0", "**/*.md").Run(); err != nil {
 				tf.Error(err)
 			}
 		},


### PR DESCRIPTION
## Why

https://github.com/igorshubovych/markdownlint-cli/releases/tag/v0.32.0

## What

Bump markdownlintcli to v0.32.0
