### PR TITLE
Use dependabot for bumping markdownlint-cli

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/build"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ gendependabot: # generate dependabot.yml
 	@printf "version: 2\n" >> ${DEPENDABOT_PATH}
 	@printf "updates:\n" >> ${DEPENDABOT_PATH}
 	@printf "  - package-ecosystem: \"github-actions\"\n    directory: \"/\"\n    schedule:\n      interval: \"daily\"\n" >> ${DEPENDABOT_PATH}
+	@printf "  - package-ecosystem: \"docker\"\n    directory: \"/build\"\n    schedule:\n      interval: \"daily\"\n" >> ${DEPENDABOT_PATH}
 	@echo "Add entry for \"/\""
 	@printf "  - package-ecosystem: \"gomod\"\n    directory: \"/\"\n    schedule:\n      interval: \"daily\"\n" >> ${DEPENDABOT_PATH}
 	@set -e; for dir in $(filter-out ., $(ALL_MODULES)); do \

--- a/build/markdownlint-cli.dockerfile
+++ b/build/markdownlint-cli.dockerfile
@@ -1,0 +1,1 @@
+FROM ghcr.io/igorshubovych/markdownlint-cli:v0.32.0

--- a/build/pipeline.go
+++ b/build/pipeline.go
@@ -168,8 +168,13 @@ func taskMarkdownLint(skipDocker goyek.RegisteredBoolParam) goyek.Task {
 				tf.Skip("skipping as Docker is needed")
 			}
 
-			if err := tf.Cmd("docker", "run", "--rm", "-v", WorkDir(tf)+":/workdir", "ghcr.io/igorshubovych/markdownlint-cli:v0.32.0", "**/*.md").Run(); err != nil {
-				tf.Error(err)
+			dockerTag := "markdownlint-cli"
+			if err := tf.Cmd("docker", "build", "-t", dockerTag, "-f", "build/markdownlint-cli.dockerfile", ".").Run(); err != nil {
+				tf.Fatal(err)
+			}
+
+			if err := tf.Cmd("docker", "run", "--rm", "-v", WorkDir(tf)+":/workdir", dockerTag, "**/*.md").Run(); err != nil {
+				tf.Fatal(err)
 			}
 		},
 	}


### PR DESCRIPTION
## Why

Fixes #1179

Use dependabot for bumping markdownlint-cli to avoid manual work as well as decrease the possibility to miss an update.

## What

- Create Dockerfile for markdownlint-cli and use it in build pipeline
- Configure dependabot to bump Dockerfiles inside `/build` directory.

## Testing

See here that it works as expected: https://github.com/pellared/splunk-otel-go/pull/889