### PR TITLE
OTEL_LOG_LEVEL accepts case insensitive values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `OTEL_LOG_LEVEL` environment variable accepts case insensitive values. (#1374)
+
 ## [1.1.0] - 2022-07-14
 
 This release uses [OpenTelemetry Go v1.8.0][otel-v1.8.0] and

--- a/distro/logger.go
+++ b/distro/logger.go
@@ -52,8 +52,9 @@ var (
 
 // zapLevel returns the parsed zapcore.Level.
 func zapLevel(level string) zapcore.Level {
+	level = strings.ToLower(level)
 	for _, l := range logLevels {
-		if l.String() == strings.ToLower(level) {
+		if l.String() == level {
 			return l.ZapLevel()
 		}
 	}

--- a/distro/logger.go
+++ b/distro/logger.go
@@ -15,6 +15,8 @@
 package distro
 
 import (
+	"strings"
+
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
@@ -51,7 +53,7 @@ var (
 // zapLevel returns the parsed zapcore.Level.
 func zapLevel(level string) zapcore.Level {
 	for _, l := range logLevels {
-		if l.String() == level {
+		if l.String() == strings.ToLower(level) {
 			return l.ZapLevel()
 		}
 	}

--- a/distro/logger_test.go
+++ b/distro/logger_test.go
@@ -71,6 +71,7 @@ func TestZapLevel(t *testing.T) {
 		{in: "warn", want: 0},
 		{in: "error", want: 1},
 		{in: "invalid", want: -1},
+		{in: "DEBUG", want: -127}, // case insensitive
 	}
 
 	for _, tc := range testcases {

--- a/distro/logger_test.go
+++ b/distro/logger_test.go
@@ -70,8 +70,8 @@ func TestZapLevel(t *testing.T) {
 		{in: "info", want: -1},
 		{in: "warn", want: 0},
 		{in: "error", want: 1},
-		{in: "invalid", want: -1},
-		{in: "DEBUG", want: -127}, // case insensitive
+		{in: "invalid", want: -1}, // default for unrecognized value
+		{in: "DEBUG", want: -127}, // values are case insensitive
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
Fixes https://github.com/signalfx/splunk-otel-go/issues/1373