### PR TITLE
Bump GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
         include:
           - os: ubuntu-20.04
             run-script: ./goyek.sh -v ci
-          - os: windows-2019
+          - os: windows-2022
             run-script: .\goyek.ps1 -v -skip-docker ci
-          - os: macos-10.15
+          - os: macos-11
             run-script: ./goyek.sh -v -skip-docker ci
     runs-on: ${{ matrix.os }}
     steps:
@@ -50,7 +50,7 @@ jobs:
         go-version:
         - '1.18'
         - '1.19'
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2022, macos-11]
         # GitHub Actions does not support arm* architectures on default
         # runners. It is possible to accomplish this with a self-hosted runner
         # if we want to add this in the future:
@@ -58,7 +58,7 @@ jobs:
         arch: ["386", amd64]
         exclude:
         # Not a supported Go OS/architecture.
-        - os: macos-10.15
+        - os: macos-11
           arch: "386"
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Why

Currently used macOS runner is deprecated:
- https://github.com/signalfx/splunk-otel-go/actions/runs/3394998999/jobs/5644295223
- https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners

## What

Bump the GH runners to the current "-latest".