### PR TITLE
Bump goyek

### DIFF
--- a/build/bump.go
+++ b/build/bump.go
@@ -22,9 +22,9 @@ import (
 var _ = goyek.Define(goyek.Task{
 	Name:  "bump",
 	Usage: "go get -u -t ./...",
-	Action: func(tf *goyek.TF) {
-		ForGoModules(tf, func(tf *goyek.TF) {
-			cmd.Exec(tf, "go get -u -t ./...")
+	Action: func(a *goyek.A) {
+		ForGoModules(a, func(a *goyek.A) {
+			cmd.Exec(a, "go get -u -t ./...")
 		}, dirBuild) // '/build' should be bumped manually as golangci-lint's deps often have breaking changes
 	},
 })

--- a/build/clean.go
+++ b/build/clean.go
@@ -22,7 +22,7 @@ import (
 var _ = goyek.Define(goyek.Task{
 	Name:  "clean",
 	Usage: "remove git ignored files",
-	Action: func(tf *goyek.TF) {
-		cmd.Exec(tf, "git clean -fXd")
+	Action: func(a *goyek.A) {
+		cmd.Exec(a, "git clean -fXd")
 	},
 })

--- a/build/diff.go
+++ b/build/diff.go
@@ -25,14 +25,14 @@ import (
 var diff = goyek.Define(goyek.Task{
 	Name:  "diff",
 	Usage: "git diff",
-	Action: func(tf *goyek.TF) {
-		cmd.Exec(tf, "git diff --exit-code")
+	Action: func(a *goyek.A) {
+		cmd.Exec(a, "git diff --exit-code")
 
 		sb := &strings.Builder{}
-		out := io.MultiWriter(tf.Output(), sb)
-		cmd.Exec(tf, "git status --porcelain", cmd.Stdout(out))
+		out := io.MultiWriter(a.Output(), sb)
+		cmd.Exec(a, "git status --porcelain", cmd.Stdout(out))
 		if sb.Len() > 0 {
-			tf.Error("git status --porcelain returned output")
+			a.Error("git status --porcelain returned output")
 		}
 	},
 })

--- a/build/go.mod
+++ b/build/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.50.1
-	github.com/goyek/goyek/v2 v2.0.0-rc.9
+	github.com/goyek/goyek/v2 v2.0.0-rc.10
 	github.com/goyek/x v0.1.1
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
 )

--- a/build/go.mod
+++ b/build/go.mod
@@ -5,8 +5,8 @@ go 1.19
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.50.1
-	github.com/goyek/goyek/v2 v2.0.0-rc.8
-	github.com/goyek/x v0.1.0
+	github.com/goyek/goyek/v2 v2.0.0-rc.9
+	github.com/goyek/x v0.1.1
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
 )
 

--- a/build/go.sum
+++ b/build/go.sum
@@ -271,10 +271,10 @@ github.com/gostaticanalysis/nilerr v0.1.1 h1:ThE+hJP0fEp4zWLkWHWcRyI2Od0p7DlgYG3
 github.com/gostaticanalysis/nilerr v0.1.1/go.mod h1:wZYb6YI5YAxxq0i1+VJbY0s2YONW0HU0GPE3+5PWN4A=
 github.com/gostaticanalysis/testutil v0.3.1-0.20210208050101-bfb5c8eec0e4/go.mod h1:D+FIZ+7OahH3ePw/izIEeH5I06eKs1IKI4Xr64/Am3M=
 github.com/gostaticanalysis/testutil v0.4.0 h1:nhdCmubdmDF6VEatUNjgUZBJKWRqugoISdUv3PPQgHY=
-github.com/goyek/goyek/v2 v2.0.0-rc.8 h1:C+NKVE1Gg61tJdGmU4yhyPvZNbyCd6Y6EcEZrwEYojU=
-github.com/goyek/goyek/v2 v2.0.0-rc.8/go.mod h1:qtHlK7t/dYs1Dw7mLXjEVmgE3nccNa7mQW/RmasOoYg=
-github.com/goyek/x v0.1.0 h1:/9HDwBqc7KG+4goVfbBZtZh0BYt+7ZEsJV42163TUsg=
-github.com/goyek/x v0.1.0/go.mod h1:5FhgNhbEC/3RAye/VLB4TO98Zr9rKA0ZWD0Z/kh+J8k=
+github.com/goyek/goyek/v2 v2.0.0-rc.9 h1:hiwI1Wv4+vkONjzogJiNIwI/VyTSj2HfzgPSlPcTlNI=
+github.com/goyek/goyek/v2 v2.0.0-rc.9/go.mod h1:qtHlK7t/dYs1Dw7mLXjEVmgE3nccNa7mQW/RmasOoYg=
+github.com/goyek/x v0.1.1 h1:0zHFG9klerC/W7MDxMBqh24vixJIJB6SOEOQfKLThG8=
+github.com/goyek/x v0.1.1/go.mod h1:QMOv+BBvRk0PWQpBoxOjD1gHiXHqORNyOLClJb4WKiA=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=

--- a/build/go.sum
+++ b/build/go.sum
@@ -271,8 +271,9 @@ github.com/gostaticanalysis/nilerr v0.1.1 h1:ThE+hJP0fEp4zWLkWHWcRyI2Od0p7DlgYG3
 github.com/gostaticanalysis/nilerr v0.1.1/go.mod h1:wZYb6YI5YAxxq0i1+VJbY0s2YONW0HU0GPE3+5PWN4A=
 github.com/gostaticanalysis/testutil v0.3.1-0.20210208050101-bfb5c8eec0e4/go.mod h1:D+FIZ+7OahH3ePw/izIEeH5I06eKs1IKI4Xr64/Am3M=
 github.com/gostaticanalysis/testutil v0.4.0 h1:nhdCmubdmDF6VEatUNjgUZBJKWRqugoISdUv3PPQgHY=
-github.com/goyek/goyek/v2 v2.0.0-rc.9 h1:hiwI1Wv4+vkONjzogJiNIwI/VyTSj2HfzgPSlPcTlNI=
 github.com/goyek/goyek/v2 v2.0.0-rc.9/go.mod h1:qtHlK7t/dYs1Dw7mLXjEVmgE3nccNa7mQW/RmasOoYg=
+github.com/goyek/goyek/v2 v2.0.0-rc.10 h1:cpNa6jLQPq30a7LkAlsAoXL0FxB4yg/zy4eWULNh8wI=
+github.com/goyek/goyek/v2 v2.0.0-rc.10/go.mod h1:qtHlK7t/dYs1Dw7mLXjEVmgE3nccNa7mQW/RmasOoYg=
 github.com/goyek/x v0.1.1 h1:0zHFG9klerC/W7MDxMBqh24vixJIJB6SOEOQfKLThG8=
 github.com/goyek/x v0.1.1/go.mod h1:QMOv+BBvRk0PWQpBoxOjD1gHiXHqORNyOLClJb4WKiA=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=

--- a/build/golint.go
+++ b/build/golint.go
@@ -22,12 +22,12 @@ import (
 var golint = goyek.Define(goyek.Task{
 	Name:  "golint",
 	Usage: "golangci-lint --fix",
-	Action: func(tf *goyek.TF) {
-		if !cmd.Exec(tf, "go install github.com/golangci/golangci-lint/cmd/golangci-lint", cmd.Dir(dirBuild)) {
+	Action: func(a *goyek.A) {
+		if !cmd.Exec(a, "go install github.com/golangci/golangci-lint/cmd/golangci-lint", cmd.Dir(dirBuild)) {
 			return
 		}
-		ForGoModules(tf, func(tf *goyek.TF) {
-			cmd.Exec(tf, "golangci-lint run --fix")
+		ForGoModules(a, func(a *goyek.A) {
+			cmd.Exec(a, "golangci-lint run --fix")
 		})
 	},
 })

--- a/build/helpers.go
+++ b/build/helpers.go
@@ -26,8 +26,8 @@ import (
 
 // ForGoModules is a helper that executes given function
 // in each directory containing go.mod file.
-func ForGoModules(tf *goyek.TF, fn func(tf *goyek.TF), ignoredPaths ...string) {
-	tf.Helper()
+func ForGoModules(a *goyek.A, fn func(a *goyek.A), ignoredPaths ...string) {
+	a.Helper()
 
 	var goModDirs []string
 	_ = filepath.WalkDir(".", func(path string, dir fs.DirEntry, err error) error {
@@ -52,41 +52,41 @@ func ForGoModules(tf *goyek.TF, fn func(tf *goyek.TF), ignoredPaths ...string) {
 
 	for _, goModDir := range goModDirs {
 		func() {
-			tf.Helper()
-			curDir := WorkDir(tf)
-			defer ChDir(tf, curDir)
+			a.Helper()
+			curDir := WorkDir(a)
+			defer ChDir(a, curDir)
 
-			tf.Log("Go Module: ", goModDir)
-			ChDir(tf, goModDir)
+			a.Log("Go Module: ", goModDir)
+			ChDir(a, goModDir)
 
-			fn(tf) // execute function in file containing go.mod
+			fn(a) // execute function in file containing go.mod
 		}()
 	}
 }
 
 // WorkDir returns current working directory.
-func WorkDir(tf *goyek.TF) string {
-	tf.Helper()
+func WorkDir(a *goyek.A) string {
+	a.Helper()
 
 	curDir, err := os.Getwd()
 	if err != nil {
-		tf.Fatal(err)
+		a.Fatal(err)
 	}
 	return curDir
 }
 
 // ChDir changes the working directory.
-func ChDir(tf *goyek.TF, path string) {
-	tf.Helper()
+func ChDir(a *goyek.A, path string) {
+	a.Helper()
 
 	if err := os.Chdir(path); err != nil {
-		tf.Fatal(err)
+		a.Fatal(err)
 	}
 }
 
 // Find returns all files with given extension.
-func Find(tf *goyek.TF, ext string) []string {
-	tf.Helper()
+func Find(a *goyek.A, ext string) []string {
+	a.Helper()
 
 	var files []string
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
@@ -99,17 +99,17 @@ func Find(tf *goyek.TF, ext string) []string {
 		return nil
 	})
 	if err != nil {
-		tf.Fatal(err)
+		a.Fatal(err)
 	}
 	return files
 }
 
 // RandString returns securely generated hex-string.
-func RandString(tf *goyek.TF, length int) string {
-	tf.Helper()
+func RandString(a *goyek.A, length int) string {
+	a.Helper()
 
 	if length < 1 {
-		tf.Fatal("length must be greater than 0")
+		a.Fatal("length must be greater than 0")
 	}
 
 	n := length / 2
@@ -119,7 +119,7 @@ func RandString(tf *goyek.TF, length int) string {
 
 	b := make([]byte, n)
 	if _, err := rand.Read(b); err != nil {
-		tf.Fatal(err)
+		a.Fatal(err)
 	}
 	return hex.EncodeToString(b)[:length]
 }

--- a/build/helpers_test.go
+++ b/build/helpers_test.go
@@ -30,9 +30,9 @@ func TestRandString(t *testing.T) {
 	}
 	for _, length := range testCases {
 		t.Run(strconv.Itoa(length), func(t *testing.T) {
-			action := func(tf *goyek.TF) {
-				if got := RandString(tf, length); len(got) != length {
-					t.Errorf("got length %v, want %v", len(got), length) // for invalid input this line is not even executed as RandString calls tf.Fatal
+			action := func(a *goyek.A) {
+				if got := RandString(a, length); len(got) != length {
+					t.Errorf("got length %v, want %v", len(got), length) // for invalid input this line is not even executed as RandString calls a.Fatal
 				}
 			}
 
@@ -51,8 +51,8 @@ func TestRandString_invalid(t *testing.T) {
 	}
 	for _, length := range testCases {
 		t.Run(strconv.Itoa(length), func(t *testing.T) {
-			action := func(tf *goyek.TF) {
-				RandString(tf, length)
+			action := func(a *goyek.A) {
+				RandString(a, length)
 				t.Error("should not return for invalid input")
 			}
 

--- a/build/mdlint.go
+++ b/build/mdlint.go
@@ -24,19 +24,19 @@ import (
 var mdlint = goyek.Define(goyek.Task{
 	Name:  "mdlint",
 	Usage: "markdownlint-cli (uses docker)",
-	Action: func(tf *goyek.TF) {
+	Action: func(a *goyek.A) {
 		if *flagSkipDocker {
-			tf.Skip("skipping as Docker is needed")
+			a.Skip("skipping as Docker is needed")
 		}
 
-		mdFiles := Find(tf, ".md")
+		mdFiles := Find(a, ".md")
 		if len(mdFiles) == 0 {
-			tf.Skip("no .md files")
+			a.Skip("no .md files")
 		}
 
-		if !cmd.Exec(tf, "docker build -t markdownlint-cli -f build/markdownlint-cli.dockerfile .") {
+		if !cmd.Exec(a, "docker build -t markdownlint-cli -f build/markdownlint-cli.dockerfile .") {
 			return
 		}
-		cmd.Exec(tf, "docker run --rm -v '"+WorkDir(tf)+":/workdir' markdownlint-cli "+strings.Join(mdFiles, " "))
+		cmd.Exec(a, "docker run --rm -v '"+WorkDir(a)+":/workdir' markdownlint-cli "+strings.Join(mdFiles, " "))
 	},
 })

--- a/build/mod.go
+++ b/build/mod.go
@@ -22,9 +22,9 @@ import (
 var mod = goyek.Define(goyek.Task{
 	Name:  "mod",
 	Usage: "go mod tidy",
-	Action: func(tf *goyek.TF) {
-		ForGoModules(tf, func(tf *goyek.TF) {
-			cmd.Exec(tf, "go mod tidy")
+	Action: func(a *goyek.A) {
+		ForGoModules(a, func(a *goyek.A) {
+			cmd.Exec(a, "go mod tidy")
 		})
 	},
 })

--- a/build/spell.go
+++ b/build/spell.go
@@ -24,15 +24,15 @@ import (
 var spell = goyek.Define(goyek.Task{
 	Name:  "spell",
 	Usage: "misspell",
-	Action: func(tf *goyek.TF) {
-		mdFiles := Find(tf, ".md")
+	Action: func(a *goyek.A) {
+		mdFiles := Find(a, ".md")
 		if len(mdFiles) == 0 {
-			tf.Skip("no .md files")
+			a.Skip("no .md files")
 		}
 
-		if !cmd.Exec(tf, "go install github.com/client9/misspell/cmd/misspell", cmd.Dir(dirBuild)) {
+		if !cmd.Exec(a, "go install github.com/client9/misspell/cmd/misspell", cmd.Dir(dirBuild)) {
 			return
 		}
-		cmd.Exec(tf, "misspell -error -locale=US -w "+strings.Join(mdFiles, " "))
+		cmd.Exec(a, "misspell -error -locale=US -w "+strings.Join(mdFiles, " "))
 	},
 })


### PR DESCRIPTION
## Why

There is breaking change in goyek: `TF` type renamed to `A`. Therefore the bump has to be done manually.

Reference: https://github.com/goyek/goyek/releases/tag/v2.0.0-rc.9

## What

Bump `github.com/goyek/goyek/v2` to `v2.0.0-rc.10`.

Bump `github.com/goyek/x` to `v0.1.1`.