### PR TITLE
Update to semconv v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This upgrades [OpenTelemetry Go to v1.12.0/v0.35.0][otel-v1.12.0] and
 
 - Add the `NetSockFamily` field to the `ConnectionConfig` in
   `github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql`.
-  This is used to define the protocol address family used for communication to
+  This is used to define the protocol address family used for communication with
   the database. (#1749)
 - Update `go.opentelemetry.io/otel/semconv` to `v1.17.0` in the following
   packages. (#1749)
@@ -49,8 +49,8 @@ This upgrades [OpenTelemetry Go to v1.12.0/v0.35.0][otel-v1.12.0] and
 
 - The `NetTransportIP` and `NetTransportUnix` variables from
   `github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql`
-  are deprecated as they are no longer supported in upstream semantic
-  conventions. Use an appropriate `NetSockFamily*` variable instead. (#1749)
+  are deprecated as they are no longer available in `go.opentelemetry.io/otel/semconv/v1.17.0`.
+  Use an appropriate `NetSockFamily*` variable instead. (#1749)
 
 ## [1.2.0] - 2023-01-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,41 @@ This upgrades [OpenTelemetry Go to v1.12.0/v0.35.0][otel-v1.12.0] and
   `github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql`
   is no longer orphaned. (#1682)
 
+### Added
+
+- The `NetSockFamily` type and related variables to be use in the
+  `ConnectionConfig` from
+  `github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql`.
+  (#1749)
+
+### Changed
+
+- Add the `NetSockFamily` field to the `ConnectionConfig` in
+  `github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql`.
+  This is used to define the protocol address family used for communication to
+  the database. (#1749)
+- Update `go.opentelemetry.io/otel/semconv` to `v1.17.0` in the following
+  packages. (#1749)
+  - `github.com/signalfx/splunk-otel-go/distro`
+  - `github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql`
+  - `github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka`
+  - `github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi`
+  - `github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql`
+  - `github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo`
+  - `github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx`
+  - `github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx`
+  - `github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb`
+  - `github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb`
+  - `github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic`
+  - `github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go`
+
+### Deprecated
+
+- The `NetTransportIP` and `NetTransportUnix` variables from
+  `github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql`
+  are deprecated as they are no longer supported in upstream semantic
+  conventions. Use an appropriate `NetSockFamily*` variable instead. (#1749)
+
 ## [1.2.0] - 2023-01-11
 
 This upgrades [OpenTelemetry Go to v1.11.2/v0.34.0][otel-v1.11.2] and

--- a/distro/otel.go
+++ b/distro/otel.go
@@ -31,7 +31,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
 	splunkotel "github.com/signalfx/splunk-otel-go"
 )

--- a/instrumentation/database/sql/splunksql/config.go
+++ b/instrumentation/database/sql/splunksql/config.go
@@ -24,7 +24,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"
@@ -172,6 +172,9 @@ type ConnectionConfig struct {
 	Port int
 	// NetTransport is the transport protocol used to connect to the database.
 	NetTransport NetTransport
+	// NetSockFamily is the protocol address family used for communication to
+	// the database.
+	NetSockFamily NetSockFamily
 }
 
 // Attributes returns the connection settings as attributes compliant with
@@ -192,17 +195,23 @@ func (c ConnectionConfig) Attributes() ([]attribute.KeyValue, error) { //nolint:
 	}
 	if c.Host != "" {
 		if ip := net.ParseIP(c.Host); ip != nil {
-			attrs = append(attrs, semconv.NetPeerIPKey.String(ip.String()))
+			attrs = append(attrs, semconv.NetSockPeerAddrKey.String(ip.String()))
+			if c.Port > 0 {
+				attrs = append(attrs, semconv.NetSockPeerPortKey.Int(c.Port))
+			}
 		} else {
 			attrs = append(attrs, semconv.NetPeerNameKey.String(c.Host))
+			if c.Port > 0 {
+				attrs = append(attrs, semconv.NetPeerPortKey.Int(c.Port))
+			}
 		}
 	} else {
 		errs = append(errs, "missing required peer IP or hostname")
 	}
-	if c.Port > 0 {
-		attrs = append(attrs, semconv.NetPeerPortKey.Int(c.Port))
-	}
 	attrs = append(attrs, c.NetTransport.Attribute())
+	if a := c.NetSockFamily.Attribute(); a.Key.Defined() {
+		attrs = append(attrs, a)
+	}
 
 	var err error
 	if len(errs) > 0 {

--- a/instrumentation/database/sql/splunksql/conn.go
+++ b/instrumentation/database/sql/splunksql/conn.go
@@ -19,7 +19,7 @@ import (
 	"database/sql/driver"
 	"errors"
 
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"

--- a/instrumentation/database/sql/splunksql/dbsystem.go
+++ b/instrumentation/database/sql/splunksql/dbsystem.go
@@ -16,7 +16,7 @@ package splunksql
 
 import (
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 )
 
 // DBSystem is a database system type.

--- a/instrumentation/database/sql/splunksql/example_sql_test.go
+++ b/instrumentation/database/sql/splunksql/example_sql_test.go
@@ -38,7 +38,8 @@ func ExampleRegister() {
 				User:             user,
 				Host:             host,
 				Port:             9876,
-				NetTransport:     splunksql.NetTransportIP,
+				NetTransport:     splunksql.NetTransportTCP,
+				NetSockFamily:    splunksql.NetSockFamilyInet,
 			}, nil
 		},
 	})

--- a/instrumentation/database/sql/splunksql/example_test.go
+++ b/instrumentation/database/sql/splunksql/example_test.go
@@ -19,7 +19,7 @@ import (
 	"log"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
 )
@@ -43,7 +43,7 @@ var (
 		// Do not include passwords!
 		semconv.DBConnectionStringKey.String(sanitized),
 		semconv.DBUserKey.String(user),
-		// Use semconv.NetPeerIPKey if connecting via an IP address. If
+		// Use semconv.NetSockPeerAddrKey if connecting via an IP address. If
 		// connecting via a Unix socket, use this attribute key.
 		semconv.NetPeerNameKey.String(host),
 		semconv.NetPeerPortKey.Int(port),

--- a/instrumentation/database/sql/splunksql/stmt.go
+++ b/instrumentation/database/sql/splunksql/stmt.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"database/sql/driver"
 
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"

--- a/instrumentation/database/sql/splunksql/test/suite_test.go
+++ b/instrumentation/database/sql/splunksql/test/suite_test.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	traceapi "go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"

--- a/instrumentation/database/sql/splunksql/transport.go
+++ b/instrumentation/database/sql/splunksql/transport.go
@@ -22,10 +22,14 @@ import (
 // NetTransport is a communication transport protocol.
 type NetTransport attribute.KeyValue
 
-// Attribute returns t as an attribute KeyValue. If t is empty the returned
-// attribute will default to a NetTransportOther.
+// Attribute returns t as an attribute KeyValue. If t is empty or a deprecated
+// value, the returned attribute will default to a NetTransportOther.
 func (t NetTransport) Attribute() attribute.KeyValue {
 	if !t.Key.Defined() {
+		return semconv.NetTransportOther
+	}
+	switch t {
+	case NetTransportIP, NetTransportUnix:
 		return semconv.NetTransportOther
 	}
 	return attribute.KeyValue(t)

--- a/instrumentation/database/sql/splunksql/transport.go
+++ b/instrumentation/database/sql/splunksql/transport.go
@@ -38,6 +38,11 @@ var (
 	NetTransportPipe   = NetTransport(semconv.NetTransportPipe)
 	NetTransportInProc = NetTransport(semconv.NetTransportInProc)
 	NetTransportOther  = NetTransport(semconv.NetTransportOther)
+
+	// Deprecated: Use appropriate NetSockFamily* instead.
+	NetTransportIP = NetTransport(semconv.NetTransportKey.String("ip"))
+	// Deprecated: Use appropriate NetSockFamily* instead.
+	NetTransportUnix = NetTransport(semconv.NetTransportKey.String("unix"))
 )
 
 // NetSockFamily is a protocol address family used for communication.
@@ -49,7 +54,7 @@ func (s NetSockFamily) Attribute() attribute.KeyValue {
 	return attribute.KeyValue(s)
 }
 
-// Valid protocol address famlies.
+// Valid protocol address families.
 var (
 	NetSockFamilyInet  = NetSockFamily(semconv.NetSockFamilyInet)
 	NetSockFamilyInet6 = NetSockFamily(semconv.NetSockFamilyInet6)

--- a/instrumentation/database/sql/splunksql/transport.go
+++ b/instrumentation/database/sql/splunksql/transport.go
@@ -16,7 +16,7 @@ package splunksql
 
 import (
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 )
 
 // NetTransport is a communication transport protocol.
@@ -35,9 +35,23 @@ func (t NetTransport) Attribute() attribute.KeyValue {
 var (
 	NetTransportTCP    = NetTransport(semconv.NetTransportTCP)
 	NetTransportUDP    = NetTransport(semconv.NetTransportUDP)
-	NetTransportIP     = NetTransport(semconv.NetTransportIP)
-	NetTransportUnix   = NetTransport(semconv.NetTransportUnix)
 	NetTransportPipe   = NetTransport(semconv.NetTransportPipe)
 	NetTransportInProc = NetTransport(semconv.NetTransportInProc)
 	NetTransportOther  = NetTransport(semconv.NetTransportOther)
+)
+
+// NetSockFamily is a protocol address family used for communication.
+type NetSockFamily attribute.KeyValue
+
+// Attribute returns t as an attribute KeyValue. If s is empty the returned
+// attribute will also be an empty, undefined, KeyValue.
+func (s NetSockFamily) Attribute() attribute.KeyValue {
+	return attribute.KeyValue(s)
+}
+
+// Valid protocol address famlies.
+var (
+	NetSockFamilyInet  = NetSockFamily(semconv.NetSockFamilyInet)
+	NetSockFamilyInet6 = NetSockFamily(semconv.NetSockFamilyInet6)
+	NetSockFamilyUnix  = NetSockFamily(semconv.NetSockFamilyUnix)
 )

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/config.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/config.go
@@ -21,7 +21,7 @@ package splunkkafka
 import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/internal"

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/consumer.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/consumer.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
@@ -149,10 +149,10 @@ func (c *Consumer) startSpan(msg *kafka.Message) consumerSpan {
 	offset := strconv.FormatInt(int64(msg.TopicPartition.Offset), base10)
 	opts := c.cfg.MergedSpanStartOptions(
 		trace.WithAttributes(
-			semconv.MessagingDestinationKey.String(*msg.TopicPartition.Topic),
+			semconv.MessagingSourceNameKey.String(*msg.TopicPartition.Topic),
 			semconv.MessagingMessageIDKey.String(offset),
 			semconv.MessagingKafkaMessageKeyKey.String(string(msg.Key)),
-			semconv.MessagingKafkaPartitionKey.Int64(int64(msg.TopicPartition.Partition)),
+			semconv.MessagingKafkaSourcePartitionKey.Int64(int64(msg.TopicPartition.Partition)),
 		),
 		trace.WithSpanKind(trace.SpanKindConsumer),
 	)

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/consumer_test.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/consumer_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -165,12 +165,12 @@ func TestConsumerSpan(t *testing.T) {
 		assert.Contains(t, attrs, semconv.MessagingSystemKey.String("kafka"))
 		assert.Contains(t, attrs, commonAttr)
 		assert.Contains(t, attrs, semconv.MessagingDestinationKindTopic)
-		assert.Contains(t, attrs, semconv.MessagingDestinationKey.String(testTopic))
+		assert.Contains(t, attrs, semconv.MessagingSourceNameKey.String(testTopic))
 		assert.Contains(t, attrs, semconv.MessagingOperationReceive)
 		assert.Contains(t, attrs, semconv.MessagingMessageIDKey.String("1"))
 		assert.Contains(t, attrs, semconv.MessagingKafkaMessageKeyKey.String(keys[i]))
 		assert.Contains(t, attrs, semconv.MessagingKafkaConsumerGroupKey.String(grpID))
-		assert.Contains(t, attrs, semconv.MessagingKafkaPartitionKey.Int64(1))
+		assert.Contains(t, attrs, semconv.MessagingKafkaSourcePartitionKey.Int64(1))
 	}
 }
 

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/producer.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/producer.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
@@ -97,10 +97,10 @@ func (p *Producer) startSpan(msg *kafka.Message) trace.Span {
 	offset := strconv.FormatInt(int64(msg.TopicPartition.Offset), base10)
 	opts := p.cfg.MergedSpanStartOptions(
 		trace.WithAttributes(
-			semconv.MessagingDestinationKey.String(*msg.TopicPartition.Topic),
+			semconv.MessagingDestinationNameKey.String(*msg.TopicPartition.Topic),
 			semconv.MessagingMessageIDKey.String(offset),
 			semconv.MessagingKafkaMessageKeyKey.String(string(msg.Key)),
-			semconv.MessagingKafkaPartitionKey.Int64(int64(msg.TopicPartition.Partition)),
+			semconv.MessagingKafkaDestinationPartitionKey.Int64(int64(msg.TopicPartition.Partition)),
 		),
 		trace.WithSpanKind(trace.SpanKindProducer),
 	)

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/producer_test.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/producer_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -110,10 +110,10 @@ func TestProducerChannelSpan(t *testing.T) {
 		attrs := record.SpanConfig.Attributes()
 		assert.Contains(t, attrs, semconv.MessagingSystemKey.String("kafka"))
 		assert.Contains(t, attrs, semconv.MessagingDestinationKindTopic)
-		assert.Contains(t, attrs, semconv.MessagingDestinationKey.String(testTopic))
+		assert.Contains(t, attrs, semconv.MessagingDestinationNameKey.String(testTopic))
 		assert.Contains(t, attrs, semconv.MessagingMessageIDKey.String("1"))
 		assert.Contains(t, attrs, semconv.MessagingKafkaMessageKeyKey.String(keys[i]))
-		assert.Contains(t, attrs, semconv.MessagingKafkaPartitionKey.Int64(1))
+		assert.Contains(t, attrs, semconv.MessagingKafkaDestinationPartitionKey.Int64(1))
 	}
 }
 
@@ -169,9 +169,9 @@ func TestProduceSpan(t *testing.T) {
 		assert.Contains(t, attrs, semconv.MessagingSystemKey.String("kafka"))
 		assert.Contains(t, attrs, commonAttr)
 		assert.Contains(t, attrs, semconv.MessagingDestinationKindTopic)
-		assert.Contains(t, attrs, semconv.MessagingDestinationKey.String(testTopic))
+		assert.Contains(t, attrs, semconv.MessagingDestinationNameKey.String(testTopic))
 		assert.Contains(t, attrs, semconv.MessagingMessageIDKey.String("1"))
 		assert.Contains(t, attrs, semconv.MessagingKafkaMessageKeyKey.String(keys[i]))
-		assert.Contains(t, attrs, semconv.MessagingKafkaPartitionKey.Int64(1))
+		assert.Contains(t, attrs, semconv.MessagingKafkaDestinationPartitionKey.Int64(1))
 	}
 }

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/kafka_test.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/kafka_test.go
@@ -33,7 +33,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	traceapi "go.opentelemetry.io/otel/trace"
 	"go.uber.org/goleak"
 
@@ -308,10 +308,10 @@ func assertProducerSpan(t *testing.T, span trace.ReadOnlySpan) {
 	attrs := span.Attributes()
 	assert.Contains(t, attrs, semconv.MessagingSystemKey.String("kafka"))
 	assert.Contains(t, attrs, semconv.MessagingDestinationKindTopic)
-	assert.Contains(t, attrs, semconv.MessagingDestinationKey.String(testTopic))
+	assert.Contains(t, attrs, semconv.MessagingDestinationNameKey.String(testTopic))
 	assert.Contains(t, attrs, semconv.MessagingMessageIDKey.String("0"))
 	assert.Contains(t, attrs, semconv.MessagingKafkaMessageKeyKey.String(string(key)))
-	assert.Contains(t, attrs, semconv.MessagingKafkaPartitionKey.Int64(0))
+	assert.Contains(t, attrs, semconv.MessagingKafkaDestinationPartitionKey.Int64(0))
 }
 
 func assertConsumerSpan(t *testing.T, span trace.ReadOnlySpan) {
@@ -320,11 +320,11 @@ func assertConsumerSpan(t *testing.T, span trace.ReadOnlySpan) {
 	attrs := span.Attributes()
 	assert.Contains(t, attrs, semconv.MessagingSystemKey.String("kafka"))
 	assert.Contains(t, attrs, semconv.MessagingDestinationKindTopic)
-	assert.Contains(t, attrs, semconv.MessagingDestinationKey.String(testTopic))
+	assert.Contains(t, attrs, semconv.MessagingSourceNameKey.String(testTopic))
 	assert.Contains(t, attrs, semconv.MessagingOperationReceive)
 	assert.Contains(t, attrs, semconv.MessagingKafkaConsumerGroupKey.String(testGroupID))
 	assert.Contains(t, attrs, semconv.MessagingKafkaMessageKeyKey.String(string(key)))
-	assert.Contains(t, attrs, semconv.MessagingKafkaPartitionKey.Int64(0))
+	assert.Contains(t, attrs, semconv.MessagingKafkaSourcePartitionKey.Int64(0))
 }
 
 func requireEventIsMessage(t *testing.T, e kafka.Event) *kafka.Message {

--- a/instrumentation/github.com/go-chi/chi/splunkchi/test/chi_test.go
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/test/chi_test.go
@@ -35,7 +35,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	traceapi "go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi"
@@ -121,7 +121,6 @@ func assertSpan(path string, otelCode codes.Code, httpCode int) func(*testing.T,
 		assert.Contains(t, attrs, semconv.HTTPSchemeHTTP)
 		assert.Contains(t, attrs, semconv.HTTPStatusCodeKey.Int(httpCode))
 		assert.Contains(t, attrs, semconv.HTTPFlavorHTTP11)
-		assert.Contains(t, attrs, semconv.NetTransportTCP)
 
 		keys := make(map[attribute.Key]struct{}, len(attrs))
 		for _, a := range attrs {
@@ -131,10 +130,9 @@ func assertSpan(path string, otelCode codes.Code, httpCode int) func(*testing.T,
 		// These key values are potentially dynamic. Test an attribute
 		// with this key is set regardless of its value.
 		wantKeys := []attribute.Key{
-			semconv.HTTPHostKey,
-			semconv.NetPeerIPKey,
-			semconv.NetPeerPortKey,
 			semconv.NetHostNameKey,
+			semconv.NetSockPeerAddrKey,
+			semconv.NetSockPeerPortKey,
 		}
 		for _, k := range wantKeys {
 			assert.Contains(t, keys, k)

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/sql_test.go
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/sql_test.go
@@ -44,6 +44,7 @@ func TestDSNParser(t *testing.T) {
 				Host:             "127.0.0.1",
 				Port:             3306,
 				NetTransport:     splunksql.NetTransportTCP,
+				NetSockFamily:    splunksql.NetSockFamilyInet,
 			},
 		},
 		{
@@ -65,7 +66,8 @@ func TestDSNParser(t *testing.T) {
 				Name:             "testdb",
 				ConnectionString: "user@unix(/tmp)/testdb",
 				User:             "user",
-				NetTransport:     splunksql.NetTransportUnix,
+				NetTransport:     splunksql.NetTransportPipe,
+				NetSockFamily:    splunksql.NetSockFamilyUnix,
 			},
 		},
 	}

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/integration_test.go
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/integration_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
 	_ "github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql"

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/example_test.go
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/example_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gomodule/redigo/redis"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/option"
 	splunkredis "github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/redis"

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/conn.go
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/conn.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/gomodule/redigo/redis"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/option"

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/conn_test.go
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/conn_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/dial_test.go
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/dial_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -34,12 +34,12 @@ func TestNetAttributes(t *testing.T) {
 		"udp":        semconv.NetTransportUDP,
 		"udp4":       semconv.NetTransportUDP,
 		"udp6":       semconv.NetTransportUDP,
-		"ip":         semconv.NetTransportIP,
-		"ip4":        semconv.NetTransportIP,
-		"ip6":        semconv.NetTransportIP,
-		"unix":       semconv.NetTransportUnix,
-		"unixgram":   semconv.NetTransportUnix,
-		"unixpacket": semconv.NetTransportUnix,
+		"ip":         semconv.NetTransportOther,
+		"ip4":        semconv.NetTransportOther,
+		"ip6":        semconv.NetTransportOther,
+		"unix":       semconv.NetTransportInProc,
+		"unixgram":   semconv.NetTransportInProc,
+		"unixpacket": semconv.NetTransportInProc,
 		"redis":      semconv.NetTransportOther,
 		"rediss":     semconv.NetTransportOther,
 		"":           semconv.NetTransportOther,
@@ -55,11 +55,11 @@ func TestNetAttributes(t *testing.T) {
 			semconv.NetPeerPortKey.Int(80),
 		},
 		"127.0.0.1": {
-			semconv.NetPeerIPKey.String("127.0.0.1"),
+			semconv.NetSockPeerAddrKey.String("127.0.0.1"),
 		},
 		"127.0.0.1:80": {
-			semconv.NetPeerIPKey.String("127.0.0.1"),
-			semconv.NetPeerPortKey.Int(80),
+			semconv.NetSockPeerAddrKey.String("127.0.0.1"),
+			semconv.NetSockPeerPortKey.Int(80),
 		},
 	}
 

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/redis_test.go
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/redis_test.go
@@ -36,7 +36,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	traceapi "go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/option"
@@ -233,7 +233,7 @@ func assertSpans(t *testing.T, n int, parentSpanName string, spans []trace.ReadO
 		assert.Contains(t, attrs, semconv.NetTransportTCP)
 		assert.Contains(t, attrs, semconv.NetPeerPortKey.Int(port))
 		if ip := net.ParseIP(host); ip != nil {
-			assert.Containsf(t, attrs, semconv.NetPeerIPKey.String(ip.String()), "address %q", addr)
+			assert.Containsf(t, attrs, semconv.NetSockPeerAddrKey.String(ip.String()), "address %q", addr)
 		} else {
 			assert.Containsf(t, attrs, semconv.NetPeerNameKey.String(host), "address %q", addr)
 		}

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/sql.go
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/sql.go
@@ -40,6 +40,7 @@
 package splunkpgx
 
 import (
+	"net"
 	"net/url"
 	"strings"
 
@@ -78,9 +79,17 @@ func DSNParser(dataSourceName string) (splunksql.ConnectionConfig, error) {
 		connCfg.Host = "localhost"
 	}
 	if strings.HasPrefix(connCfg.Host, "/") {
-		connCfg.NetTransport = splunksql.NetTransportUnix
+		connCfg.NetTransport = splunksql.NetTransportPipe
+		connCfg.NetSockFamily = splunksql.NetSockFamilyUnix
 	} else {
 		connCfg.NetTransport = splunksql.NetTransportTCP
+		if ip := net.ParseIP(connCfg.Host); ip != nil {
+			if ip.To4() != nil {
+				connCfg.NetSockFamily = splunksql.NetSockFamilyInet
+			} else {
+				connCfg.NetSockFamily = splunksql.NetSockFamilyInet6
+			}
+		}
 		if c.Port > 0 {
 			connCfg.Port = int(c.Port)
 		} else {

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/sql_test.go
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/sql_test.go
@@ -55,7 +55,8 @@ func TestDSNParser(t *testing.T) {
 				ConnectionString: "user=user host=/tmp/pgdb dbname=testdb",
 				User:             "user",
 				Host:             "/tmp/pgdb",
-				NetTransport:     splunksql.NetTransportUnix,
+				NetTransport:     splunksql.NetTransportPipe,
+				NetSockFamily:    splunksql.NetSockFamilyUnix,
 			},
 		},
 	}

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/test/integration_test.go
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/test/integration_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
 	_ "github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx"

--- a/instrumentation/github.com/lib/pq/splunkpq/sql_test.go
+++ b/instrumentation/github.com/lib/pq/splunkpq/sql_test.go
@@ -56,7 +56,8 @@ func TestDSNParser(t *testing.T) {
 				User:             "user",
 				Host:             "/tmp/pgdb",
 				Port:             5432,
-				NetTransport:     splunksql.NetTransportUnix,
+				NetTransport:     splunksql.NetTransportPipe,
+				NetSockFamily:    splunksql.NetSockFamilyUnix,
 			},
 		},
 	}

--- a/instrumentation/github.com/lib/pq/splunkpq/test/integration_test.go
+++ b/instrumentation/github.com/lib/pq/splunkpq/test/integration_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
 	_ "github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq"

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/config.go
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/config.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/internal"

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/db.go
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/db.go
@@ -24,7 +24,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/storage"
 	"github.com/syndtr/goleveldb/leveldb/util"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/iterator.go
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/iterator.go
@@ -17,7 +17,7 @@ package splunkleveldb
 import (
 	"github.com/syndtr/goleveldb/leveldb/iterator"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/snapshot.go
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/snapshot.go
@@ -21,7 +21,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/iterator"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/splunkleveldb_test.go
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/splunkleveldb_test.go
@@ -30,7 +30,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	traceapi "go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb"

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/transaction.go
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/transaction.go
@@ -21,7 +21,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/iterator"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/buntdb.go
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/buntdb.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/tidwall/buntdb"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/config.go
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/config.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/internal"

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/buntdb_test.go
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/buntdb_test.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	traceapi "go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb"

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/elastic.go
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/elastic.go
@@ -22,7 +22,8 @@ import (
 
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"go.opentelemetry.io/otel/semconv/v1.17.0/httpconv"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
@@ -62,8 +63,7 @@ var _ http.RoundTripper = (*roundTripper)(nil)
 
 func (rt *roundTripper) RoundTrip(r *http.Request) (resp *http.Response, err error) {
 	opts := rt.cfg.MergedSpanStartOptions(
-		trace.WithAttributes(semconv.HTTPClientAttributesFromHTTPRequest(r)...),
-		trace.WithAttributes(semconv.NetAttributesFromHTTPRequest("tcp", r)...),
+		trace.WithAttributes(httpconv.ClientRequest(r)...),
 	)
 
 	tracer := rt.cfg.ResolveTracer(r.Context())
@@ -80,8 +80,8 @@ func (rt *roundTripper) RoundTrip(r *http.Request) (resp *http.Response, err err
 		span.SetStatus(codes.Error, err.Error())
 		return
 	}
-	span.SetAttributes(semconv.HTTPAttributesFromHTTPStatusCode(resp.StatusCode)...)
-	span.SetStatus(semconv.SpanStatusFromHTTPStatusCode(resp.StatusCode))
+	span.SetAttributes(httpconv.ClientResponse(resp)...)
+	span.SetStatus(httpconv.ClientStatus(resp.StatusCode))
 	return
 }
 

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/elastic_test.go
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/elastic_test.go
@@ -38,7 +38,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	apitrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic"

--- a/instrumentation/internal/config.go
+++ b/instrumentation/internal/config.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
 	splunkotel "github.com/signalfx/splunk-otel-go"

--- a/instrumentation/internal/config_test.go
+++ b/instrumentation/internal/config_test.go
@@ -25,7 +25,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
 	splunkotel "github.com/signalfx/splunk-otel-go"

--- a/instrumentation/internal/option.go
+++ b/instrumentation/internal/option.go
@@ -17,7 +17,7 @@ package internal
 import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
 	splunkotel "github.com/signalfx/splunk-otel-go"

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/splunkclient-go_test.go
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/splunkclient-go_test.go
@@ -31,7 +31,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go/option"
@@ -92,7 +92,7 @@ func TestEndToEndWrappedTransport(t *testing.T) {
 	assert.Contains(t, span.Attributes(), semconv.HTTPMethodKey.String("GET"))
 	assert.Contains(t, span.Attributes(), semconv.HTTPURLKey.String(url))
 	assert.Contains(t, span.Attributes(), semconv.HTTPSchemeHTTP)
-	assert.Contains(t, span.Attributes(), semconv.HTTPHostKey.String(strings.TrimPrefix(url, "http://")))
+	assert.Contains(t, span.Attributes(), semconv.NetHostName.String(strings.TrimPrefix(url, "http://")))
 	assert.Contains(t, span.Attributes(), semconv.HTTPFlavorHTTP11)
 	assert.Contains(t, span.Attributes(), semconv.HTTPStatusCodeKey.Int(200))
 	assert.Equal(t, codes.Unset, span.Status().Code)

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/transport.go
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/transport.go
@@ -25,7 +25,8 @@ import (
 
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"go.opentelemetry.io/otel/semconv/v1.17.0/httpconv"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/client-go/transport"
 
@@ -80,7 +81,7 @@ func (rt *roundTripper) RoundTrip(r *http.Request) (resp *http.Response, err err
 	opts = append(
 		opts,
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(semconv.HTTPClientAttributesFromHTTPRequest(r)...),
+		trace.WithAttributes(httpconv.ClientRequest(r)...),
 	)
 
 	tracer := rt.cfg.ResolveTracer(r.Context())
@@ -98,8 +99,8 @@ func (rt *roundTripper) RoundTrip(r *http.Request) (resp *http.Response, err err
 		return
 	}
 
-	span.SetAttributes(semconv.HTTPAttributesFromHTTPStatusCode(resp.StatusCode)...)
-	span.SetStatus(semconv.SpanStatusFromHTTPStatusCode(resp.StatusCode))
+	span.SetAttributes(httpconv.ClientResponse(resp)...)
+	span.SetStatus(httpconv.ClientStatus(resp.StatusCode))
 	resp.Body = &wrappedBody{ctx: ctx, span: span, body: resp.Body}
 
 	return


### PR DESCRIPTION
Related OTel specification change PRs for net/http/messaging semantic conventions:

- https://github.com/open-telemetry/opentelemetry-specification/pull/2469
- https://github.com/open-telemetry/opentelemetry-specification/pull/2614
- https://github.com/open-telemetry/opentelemetry-specification/pull/2957

### Added

- The `NetSockFamily` type and related variables to be use in the `ConnectionConfig` from `github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql`.

### Changed

- Add the `NetSockFamily` field to the `ConnectionConfig` in `github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql`. This is used to define the protocol address family used for communication to the database.
- Update `go.opentelemetry.io/otel/semconv` to `v1.17.0` in the following packages.
  - `github.com/signalfx/splunk-otel-go/distro`
  - `github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql`
  - `github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka`
  - `github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi`
  - `github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql`
  - `github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo`
  - `github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx`
  - `github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx`
  - `github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb`
  - `github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb`
  - `github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic`
  - `github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go`

### Deprecated

- The `NetTransportIP` and `NetTransportUnix` variables from `github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql` are deprecated as they are no longer supported in upstream semantic conventions. Use an appropriate `NetSockFamily*` variable instead.