### PR TITLE
Adjust Build Status badge to new shields.io API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-%23E05735)](CHANGELOG.md)
 [![LICENSE](https://img.shields.io/github/license/signalfx/splunk-otel-go)](LICENSE)
 
-[![Build Status](https://img.shields.io/github/workflow/status/signalfx/splunk-otel-go/ci)](https://github.com/signalfx/splunk-otel-go/actions?query=branch%3Amain)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/signalfx/splunk-otel-go/ci.yml?branch=main)](https://github.com/signalfx/splunk-otel-go/actions?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/signalfx/splunk-otel-go/branch/main/graph/badge.svg)](https://codecov.io/gh/signalfx/splunk-otel-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/signalfx/splunk-otel-go)](https://goreportcard.com/report/github.com/signalfx/splunk-otel-go)
 


### PR DESCRIPTION
## Why

The owners of the shield badges changed the way of serving badges for GitHub workflows. The migration steps are described in https://github.com/badges/shields/issues/8671.

## What

The badge URL is adjusted to the new shields.io API.