### PR TITLE
Use Go 1.20 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-go@v3.5.0
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - run: ${{ matrix.run-script }}
       - uses: codecov/codecov-action@v3.1.1
         with:


### PR DESCRIPTION
Developers likely use the latest release of Go in development and we want to catch any bugs (e.g. lint errors, race detection) with the this release before they are merged. Therefore, update the default version the CI system uses to be the latest.