### PR TITLE
Handle empty env vars as it they were not set

### DIFF
--- a/distro/config.go
+++ b/distro/config.go
@@ -101,10 +101,9 @@ func newConfig(opts ...Option) *config {
 }
 
 // envOr returns the environment variable value associated with key if it
-// exists, otherwise it returns alt.
+// set and not empty, otherwise it returns alt.
 func envOr(key, alt string) string {
-	v, ok := os.LookupEnv(key)
-	if ok {
+	if v := os.Getenv(key); v != "" {
 		return v
 	}
 	return alt


### PR DESCRIPTION
## Why

> The SDK MUST interpret an empty value of an environment variable the same way as when the variable is unset.

Reference: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#parsing-empty-value

## What

Handle empty env vars as it they were not set.

Currently when empty value is set then it is logging errors and fallbacks to the default value. After this change it will not longer log the error.