### PR TITLE
Update example README.md

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -28,7 +28,6 @@ Run the instrumented application:
 ```sh
 export OTEL_SERVICE_NAME="splunk-otel-go-example"
 export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=$(whoami)"
-export OTEL_METRICS_EXPORTER="otlp"
 go run .
 ```
 


### PR DESCRIPTION
`otlp` metrics exporter is now set by default.