### PR TITLE
Simplify trace provider shutdown

### DIFF
--- a/distro/otel.go
+++ b/distro/otel.go
@@ -161,13 +161,7 @@ func runTraces(c *config, res *resource.Resource) (shutdownFunc, error) {
 	traceProvider := trace.NewTracerProvider(o...)
 	otel.SetTracerProvider(traceProvider)
 
-	shutdownFn := func(ctx context.Context) error {
-		if err := traceProvider.Shutdown(ctx); err != nil {
-			return err
-		}
-		return exp.Shutdown(ctx)
-	}
-	return shutdownFn, nil
+	return traceProvider.Shutdown, nil
 }
 
 func runMetrics(c *config, res *resource.Resource) (shutdownFunc, error) {


### PR DESCRIPTION
Batch span processor takes care of exporter shutdown and it makes sure it is executed once.