### PR TITLE
Renovate to run go mod tidy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,8 @@
     "config:base"
   ],
   "ignorePaths": [],
-  "separateMajorMinor": true
+  "separateMajorMinor": true,
+  "postUpdateOptions" : [
+    "gomodTidy"
+  ]
 }


### PR DESCRIPTION
Renovate should run `go mod tidy` according to
- https://docs.renovatebot.com/configuration-options/#postupdateoptions
- https://docs.renovatebot.com/modules/manager/gomod/