### PR TITLE
[chore] Renovate to bump indirect Go modules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,12 @@
   "separateMajorMinor": true,
   "postUpdateOptions" : [
     "gomodTidy"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": true
+    }
   ]
 }


### PR DESCRIPTION
See: https://docs.renovatebot.com/modules/manager/gomod/#post-update-options

I think it would be better than relying on https://github.com/signalfx/splunk-otel-go/blob/main/build/bump.go

Also it should reduce the amount of `go mod tidy` that we need to manually commit and push.