### PR TITLE
Update renovate.json to ignore /build

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,9 @@
   "extends": [
     "config:base"
   ],
-  "ignorePaths": [],
+  "ignorePaths": [
+    "build/**"
+  ],
   "separateMajorMinor": true,
   "postUpdateOptions" : [
     "gomodTidy"


### PR DESCRIPTION
We can rely on dependabot for bumping the tools under `/build`. Bumping all transitive dependencies in `/build` is too invasive and  sometimes it was breaking e.g. golangci-lint.