### PR TITLE
Update GDI spec reference to 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Splunk Distribution of OpenTelemetry Go
 
 [![OpenTelemetry Go](https://img.shields.io/badge/OTel-1.20.0-blueviolet)](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.20.0)
-[![Splunk GDI Specification](https://img.shields.io/badge/GDI-1.3.0-blueviolet)](https://github.com/signalfx/gdi-specification/releases/tag/v1.3.0)
+[![Splunk GDI Specification](https://img.shields.io/badge/GDI-1.6.0-blueviolet)](https://github.com/signalfx/gdi-specification/releases/tag/v1.6.0)
 [![GitHub Release](https://img.shields.io/github/v/release/signalfx/splunk-otel-go?include_prereleases)](https://github.com/signalfx/splunk-otel-go/releases)
 [![Go Reference](https://pkg.go.dev/badge/github.com/signalfx/splunk-otel-go.svg)](https://pkg.go.dev/github.com/signalfx/splunk-otel-go)
 [![go.mod](https://img.shields.io/github/go-mod/go-version/signalfx/splunk-otel-go)](go.mod)


### PR DESCRIPTION
Blocked by:
- https://github.com/signalfx/splunk-otel-go/pull/2696

Fixes https://github.com/signalfx/splunk-otel-go/issues/2484