### PR TITLE
distro: Avoid merge resource conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   without bumping the Splunk Distribution (`github.com/signalfx/splunk-otel-go`).
   It fixes a merge resource runtime error, which could occur when
   the application uses a version of OpenTelemetry Go that is newer
-  than the one which the Splunk Distribution is depending on.
-  (#2759)
+  than the one which the Splunk Distribution is depending on. (#2759)
 
 ## [1.12.0] - 2024-01-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow bumping OpenTelemetry Go (`go.opentelemetry.io/otel`)
+  without bumping the Splunk Distribution (`github.com/signalfx/splunk-otel-go`).
+  It fixes a merge resource runtime error, which could occur when
+  the application uses a version of OpenTelemetry Go that is newer
+  than the one which the Splunk Distribution is depending on.
+  (#2759)
+
 ## [1.12.0] - 2024-01-18
 
 This release deprecates `jaeger-thrift-splunk` option support for `OTEL_TRACES_EXPORTER`


### PR DESCRIPTION
## Why

Mitigate https://github.com/open-telemetry/opentelemetry-go/issues/2341 in our distribution.

## What

1. Do not set the Scheme URL for Splunk resource attributes. They do not belong to the OTel semantic conventions anyway.
2. Remove reference to `semconv` package in `otel.go` when getting the `service.name` key (which is stable so it will not change) to reduce the possibility that we accidently use `semconv` again when creating the resource.