### PR TITLE
Fix release target

### DIFF
--- a/build/release.go
+++ b/build/release.go
@@ -55,6 +55,9 @@ var _ = goyek.Define(goyek.Task{
 
 		tags := strings.Split(sb.String(), "\n")
 		for _, tag := range tags {
+			if strings.Contains(tag, "Using versioning file") {
+				continue
+			}
 			cmd.Exec(a, "git push "+*flagRemote+" "+tag)
 		}
 	},


### PR DESCRIPTION
Fix for:

```sh
      release.go:58: Exec: git push upstream Using versioning file /home/rpajak/repos/splunk-otel-go/versions.yaml
fatal: invalid refspec '/home/rpajak/repos/splunk-otel-go/versions.yaml'
      release.go:58: exit status 128
```

Ignore the following `multimod` output:

```
Using versioning file [PATH]/versions.yaml
```