### PR TITLE
[chore] Renovate to not ignore any path

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:base"
   ],
+  "ignorePaths": [],
   "separateMajorMinor": true,
   "postUpdateOptions" : [
     "gomodTidy"


### PR DESCRIPTION
Renovate currently does not bump the `test` Go modules because of https://github.com/renovatebot/renovate/discussions/12755.

This PR overrides the setting making sure that no path is ignored.