### PR TITLE
example: FIPS mode on Windows

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -95,7 +95,7 @@ You can find the collected telemetry in:
 
 ### FIPS mode - Linux
 
-> [!NOTE]  
+> [!NOTE]
 > As BoringSSL is FIPS 140-2 certified, an application built using `GOEXPERIMENT=boringcrypto`
 > is more likely to be FIPS 140-2 compliant.
 > Yet Google does not provide any liability about the suitability of this code
@@ -109,3 +109,26 @@ For example:
 ```sh
 CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go run .
 ```
+
+### FIPS mode - Windows
+
+> [!NOTE]
+> Microsoft maitains [a fork of Go](https://github.com/microsoft/go)
+> that can be used to build applications
+> which are likely to be FIPS 140-2 compliant.
+> More information can be found [here](https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips).
+
+Build the instrumented application using
+[the container image containing the Microsoft build of Go](https://github.com/microsoft/go-images).
+Make sure to set `GOOS=windows GOEXPERIMENT=cngcrypto`
+and add the `requirefips` Go build tag.
+For example, using Git Bash on Windows in the root of the repository:
+
+```sh
+MSYS_NO_PATHCONV=1 docker run --rm -w /app -v $(pwd):/app mcr.microsoft.com/oss/go/microsoft/golang sh -c \
+"cd example && GOOS=windows GOEXPERIMENT=cngcrypto go build -tags=requirefips"
+```
+
+Before running the application make sure to enable the Windows FIPS policy.
+For testing purposes, Windows FIPS policy can be enabled via the registry key `HKLM\SYSTEM\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy`
+dword value `Enabled` set to `1`.

--- a/example/README.md
+++ b/example/README.md
@@ -113,9 +113,10 @@ CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go run .
 ### FIPS mode - Windows
 
 > [!NOTE]
-> Microsoft maitains [a fork of Go](https://github.com/microsoft/go)
-> that can be used to build applications
-> which are likely to be FIPS 140-2 compliant.
+> Microsoft maintains [a fork of Go](https://github.com/microsoft/go)
+> that is configurable to use a FIPS 140-2 compliant cryptography.
+> All Go applications running on Windows and intended to be
+> FIPS 140-2 compliant, should be built using this fork.
 > More information can be found [here](https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips).
 
 Build the instrumented application using


### PR DESCRIPTION
Fixes https://github.com/signalfx/splunk-otel-go/issues/3460

### Testing

All testing was done on Windows 11.

Building the app using the Microsoft's Go fork:

```sh
rpajak@LAPTOP-K6FOL8LO MINGW64 ~/repos/splunk-otel-go (fips-win)
$ MSYS_NO_PATHCONV=1 docker run --rm -w /app -v $(pwd):/app mcr.microsoft.com/oss/go/microsoft/golang sh -c \
"cd example && GOOS=windows GOEXPERIMENT=cngcrypto go build -tags=requirefips"
go: downloading golang.org/x/sync v0.10.0
...
```

Trying to run when Windows is NOT in FIPS mode:

```sh
rpajak@LAPTOP-K6FOL8LO MINGW64 ~/repos/splunk-otel-go/example (fips-win)
$ ./example.exe
panic: cngcrypto: not in FIPS mode

goroutine 1 [running]:
crypto/internal/backend.init.0()
        /usr/local/go/src/crypto/internal/backend/cng_windows.go:36 +0xb1
```

After enabling FIPS mode on Windows:

```sh
rpajak@LAPTOP-K6FOL8LO MINGW64 ~/repos/splunk-otel-go/example (fips-win)
$ ./example.exe
HTTP request:
GET / HTTP/1.1
Host: localhost:8080
Accept-Encoding: gzip
Traceparent: 00-1d2e340f28f0d929bf9970b947626c3f-09ce684cee21831a-01
User-Agent: Go-http-client/1.1


HTTP response:
HTTP/1.1 200 OK
Access-Control-Expose-Headers: Server-Timing
Date: Wed, 11 Dec 2024 11:23:32 GMT
Server-Timing: traceparent;desc="00-1d2e340f28f0d929bf9970b947626c3f-4fcd2689a9397484-01"
Content-Length: 0
```

The trace landed in Splunk o11y Cloud:

![image](https://github.com/user-attachments/assets/f1957220-4f69-41c5-93ca-32ae81affed5)
