### PR TITLE
Drop support for Go 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-go@v5.3.0
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           check-latest: true
       - run: ${{ matrix.run-script }}
       - uses: codecov/codecov-action@v5.3.1
@@ -52,8 +52,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-        - '1.22'
         - '1.23'
+        - '1.24'
         os: [ubuntu-20.04, windows-2022, macos-14]
     runs-on: ${{ matrix.os }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The release requires at least [Go 1.23].
 
 ### Removed
 
-- Drop support for [Go 1.22]. (#????)
+- Drop support for [Go 1.22]. (#3721)
 
 
 ## [1.24.0] - 2025-01-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This release adds experimental logs support. Set `OTEL_LOGS_EXPORTER=otlp` to
 enable logs support. However, take notice that, as of now, the OpenTelemetry Go
 Logs API is not stable.
 
+The release requires at least [Go 1.23].
+
 ### Added
 
 - Add logs support and `OTEL_LOGS_EXPORTER` environment variable.
@@ -22,6 +24,11 @@ Logs API is not stable.
   Currently, `OTEL_LOGS_EXPORTER` defaults to `none` as the OpenTelemetry Go
   Logs API and SDK are not stable yet. Set `OTEL_LOGS_EXPORTER=otlp` to enable
   logs support. (#3673)
+
+### Removed
+
+- Drop support for [Go 1.22]. (#????)
+
 
 ## [1.24.0] - 2025-01-22
 
@@ -742,6 +749,7 @@ an impedance mismatch with this duplicate batching.
 [contrib-v0.20.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.20.0
 [contrib-v0.19.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.19.0
 
+[Go 1.23]: https://go.dev/doc/go1.23
 [Go 1.22]: https://go.dev/doc/go1.22
 [Go 1.21]: https://go.dev/doc/go1.21
 [Go 1.20]: https://go.dev/doc/go1.20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ The release requires at least [Go 1.23].
 
 - Drop support for [Go 1.22]. (#3721)
 
-
 ## [1.24.0] - 2025-01-22
 
 This release upgrades [OpenTelemetry Go to v1.34.0/v0.56.0/v0.10.0][otel-v1.34.0]

--- a/distro/go.mod
+++ b/distro/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/distro
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/example
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/signalfx/splunk-otel-go/distro v1.24.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go
 
-go 1.21
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/instrumentation/database/sql/splunksql/go.mod
+++ b/instrumentation/database/sql/splunksql/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.24.0

--- a/instrumentation/database/sql/splunksql/test/go.mod
+++ b/instrumentation/database/sql/splunksql/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql/test
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.24.0

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/confluentinc/confluent-kafka-go v1.9.2

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/confluentinc/confluent-kafka-go v1.9.2

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/confluentinc/confluent-kafka-go/v2 v2.8.0

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/test/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/test
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/confluentinc/confluent-kafka-go/v2 v2.8.0

--- a/instrumentation/github.com/go-chi/chi/splunkchi/go.mod
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/go-chi/chi v1.5.5

--- a/instrumentation/github.com/go-chi/chi/splunkchi/test/go.mod
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi/test
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/go-chi/chi v1.5.5

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/go.mod
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/go-sql-driver/mysql v1.9.0

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/go.mod
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/ory/dockertest/v3 v3.11.0

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/go.mod
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/gomodule/redigo v1.9.2

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/go.mod
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/gomodule/redigo v1.9.2

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/go.mod
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/graph-gophers/graphql-go v1.5.0

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test/go.mod
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/graph-gophers/graphql-go v1.5.0

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/go.mod
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/jackc/pgx/v4 v4.18.3

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/test/go.mod
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx/test
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/ory/dockertest/v3 v3.11.0

--- a/instrumentation/github.com/jackc/pgx/v5/splunkpgx/go.mod
+++ b/instrumentation/github.com/jackc/pgx/v5/splunkpgx/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/jackc/pgx/v5 v5.7.2

--- a/instrumentation/github.com/jackc/pgx/v5/splunkpgx/test/go.mod
+++ b/instrumentation/github.com/jackc/pgx/v5/splunkpgx/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx/test
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/ory/dockertest/v3 v3.11.0

--- a/instrumentation/github.com/jinzhu/gorm/splunkgorm/go.mod
+++ b/instrumentation/github.com/jinzhu/gorm/splunkgorm/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/jinzhu/gorm/splunkgorm
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/jinzhu/gorm v1.9.16

--- a/instrumentation/github.com/jmoiron/sqlx/splunksqlx/go.mod
+++ b/instrumentation/github.com/jmoiron/sqlx/splunksqlx/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/jmoiron/sqlx/splunksqlx
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/jmoiron/sqlx v1.4.0

--- a/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/go.mod
+++ b/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0

--- a/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test/go.mod
+++ b/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0

--- a/instrumentation/github.com/lib/pq/splunkpq/go.mod
+++ b/instrumentation/github.com/lib/pq/splunkpq/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/lib/pq v1.10.9

--- a/instrumentation/github.com/lib/pq/splunkpq/test/go.mod
+++ b/instrumentation/github.com/lib/pq/splunkpq/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq/test
 
-go 1.22.0
+go 1.23.0
 
 replace (
 	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../../database/sql/splunksql

--- a/instrumentation/github.com/miekg/dns/splunkdns/go.mod
+++ b/instrumentation/github.com/miekg/dns/splunkdns/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/miekg/dns v1.1.63

--- a/instrumentation/github.com/miekg/dns/splunkdns/test/go.mod
+++ b/instrumentation/github.com/miekg/dns/splunkdns/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns/test
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/miekg/dns v1.1.63

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/go.mod
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.24.0

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/go.mod
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb v1.24.0

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/go.mod
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.24.0

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/go.mod
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb v1.24.0

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/go.mod
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/olivere/elastic/v7 v7.0.32

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/go.mod
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/olivere/elastic/v7 v7.0.32

--- a/instrumentation/internal/go.mod
+++ b/instrumentation/internal/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/internal
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/instrumentation/k8s.io/client-go/splunkclient-go/go.mod
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.24.0

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/go.mod
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go/transport/test
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go v1.24.0

--- a/instrumentation/net/http/splunkhttp/go.mod
+++ b/instrumentation/net/http/splunkhttp/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0


### PR DESCRIPTION
Drop support for unsupported version of Go.
This will help bumping dependencies.