### PR TITLE
Release 1.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.34.0] - 2026-08-07
+
+This release upgrades [OpenTelemetry Go to v1.45.0/v0.67.0/v0.21.0/v0.0.18][otel-v1.45.0]
+and [OpenTelemetry Go Contrib to v1.45.0/v2.5.2/v0.70.0/v0.37.2/v0.25.0/v0.20.0/v0.16.2/v0.17.0][contrib-v1.45.0].
+
 ## [1.33.0] - 2026-06-01
 
 This release upgrades [OpenTelemetry Go to v1.44.0/v0.66.0/v0.20.0/v0.0.17][otel-v1.44.0]
@@ -813,7 +818,8 @@ an impedance mismatch with this duplicate batching.
 - Add [`splunkhttp`](./instrumentation/net/http/splunkhttp) module providing
   additional Splunk specific instrumentation for `net/http`.
 
-[Unreleased]: https://github.com/signalfx/splunk-otel-go/compare/v1.33.0...HEAD
+[Unreleased]: https://github.com/signalfx/splunk-otel-go/compare/v1.34.0...HEAD
+[1.34.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v1.34.0
 [1.33.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v1.33.0
 [1.32.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v1.32.0
 [1.31.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v1.31.0
@@ -859,6 +865,7 @@ an impedance mismatch with this duplicate batching.
 [0.2.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.2.0
 [0.1.0]: https://github.com/signalfx/splunk-otel-go/releases/tag/v0.1.0
 
+[otel-v1.45.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.45.0
 [otel-v1.44.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.44.0
 [otel-v1.43.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.43.0
 [otel-v1.42.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.42.0
@@ -903,6 +910,7 @@ an impedance mismatch with this duplicate batching.
 [otel-v0.20.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.20.0
 [otel-v0.19.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.19.0
 
+[contrib-v1.45.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.45.0
 [contrib-v1.44.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.44.0
 [contrib-v1.43.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.43.0
 [contrib-v1.42.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.42.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Splunk Distribution of OpenTelemetry Go
 
-[![OpenTelemetry Go](https://img.shields.io/badge/OTel-1.44.0-blueviolet)](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.44.0)
+[![OpenTelemetry Go](https://img.shields.io/badge/OTel-1.45.0-blueviolet)](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.45.0)
 [![Splunk GDI Specification](https://img.shields.io/badge/GDI-1.9.0-blueviolet)](https://github.com/signalfx/gdi-specification/releases/tag/v1.9.0)
 [![GitHub Release](https://img.shields.io/github/v/release/signalfx/splunk-otel-go?include_prereleases)](https://github.com/signalfx/splunk-otel-go/releases)
 [![Go Reference](https://pkg.go.dev/badge/github.com/signalfx/splunk-otel-go.svg)](https://pkg.go.dev/github.com/signalfx/splunk-otel-go)

--- a/distro/version.go
+++ b/distro/version.go
@@ -16,5 +16,5 @@ package distro
 
 // Version returns the version of distro.
 func Version() string {
-	return "1.33.0"
+	return "1.34.0"
 }

--- a/example/go.mod
+++ b/example/go.mod
@@ -3,8 +3,8 @@ module github.com/signalfx/splunk-otel-go/example
 go 1.25.0
 
 require (
-	github.com/signalfx/splunk-otel-go/distro v1.33.0
-	github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp v1.33.0
+	github.com/signalfx/splunk-otel-go/distro v1.34.0
+	github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp v1.34.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0
 	golang.org/x/sync v0.22.0
 )

--- a/instrumentation/database/sql/splunksql/go.mod
+++ b/instrumentation/database/sql/splunksql/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql
 go 1.25.0
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/metric v1.45.0

--- a/instrumentation/database/sql/splunksql/test/go.mod
+++ b/instrumentation/database/sql/splunksql/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql
 go 1.25.0
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
@@ -19,7 +19,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/instrumentation/database/sql/splunksql/version.go
+++ b/instrumentation/database/sql/splunksql/version.go
@@ -16,5 +16,5 @@ package splunksql
 
 // Version returns the version of splunksql.
 func Version() string {
-	return "1.33.0"
+	return "1.34.0"
 }

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/go.mod
@@ -6,7 +6,7 @@ go 1.25.0
 
 require (
 	github.com/confluentinc/confluent-kafka-go v1.9.2
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/confluentinc/confluent-kafka-go v1.9.2
 	github.com/moby/moby/api v1.55.0
 	github.com/ory/dockertest/v4 v4.0.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
@@ -33,7 +33,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/version.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/version.go
@@ -18,5 +18,5 @@ package splunkkafka
 
 // Version returns the version of splunkkafka.
 func Version() string {
-	return "1.33.0"
+	return "1.34.0"
 }

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/confluentinc/confluent-kafka-go/v2 v2.15.0
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/test/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/test/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/confluentinc/confluent-kafka-go/v2 v2.15.0
 	github.com/moby/moby/api v1.55.0
 	github.com/ory/dockertest/v4 v4.0.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
@@ -33,7 +33,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/version.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/version.go
@@ -18,5 +18,5 @@ package splunkkafka
 
 // Version returns the version of splunkkafka.
 func Version() string {
-	return "1.33.0"
+	return "1.34.0"
 }

--- a/instrumentation/github.com/go-chi/chi/splunkchi/go.mod
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/go.mod
@@ -6,7 +6,7 @@ go 1.25.0
 
 require (
 	github.com/go-chi/chi v1.5.5
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
 )

--- a/instrumentation/github.com/go-chi/chi/splunkchi/test/go.mod
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/test/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/go-chi/chi v1.5.5
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
@@ -18,7 +18,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/instrumentation/github.com/go-chi/chi/splunkchi/version.go
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/version.go
@@ -16,5 +16,5 @@ package splunkchi
 
 // Version returns the version of splunkchi.
 func Version() string {
-	return "1.33.0"
+	return "1.34.0"
 }

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/go.mod
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/go-sql-driver/mysql v1.10.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.34.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -15,7 +15,7 @@ require (
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/go.mod
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/go.mod
@@ -5,8 +5,8 @@ go 1.25.5
 require (
 	github.com/moby/moby/api v1.55.0
 	github.com/ory/dockertest/v4 v4.0.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.33.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.34.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
@@ -33,7 +33,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/go.mod
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/go.mod
@@ -6,7 +6,7 @@ go 1.25.0
 
 require (
 	github.com/gomodule/redigo v1.9.3
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/go.mod
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require (
 	github.com/gomodule/redigo v1.9.3
 	github.com/ory/dockertest/v4 v4.0.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
@@ -32,7 +32,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/version.go
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/version.go
@@ -16,5 +16,5 @@ package splunkredigo
 
 // Version returns the version of splunkredigo.
 func Version() string {
-	return "1.33.0"
+	return "1.34.0"
 }

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/go.mod
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/go.mod
@@ -6,7 +6,7 @@ go 1.25.0
 
 require (
 	github.com/graph-gophers/graphql-go v1.10.2
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
 )

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test/go.mod
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/graph-gophers/graphql-go v1.10.2
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel/sdk v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
@@ -17,7 +17,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/version.go
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/version.go
@@ -16,5 +16,5 @@ package splunkgraphql
 
 // Version returns the version of splunkgraphql.
 func Version() string {
-	return "1.33.0"
+	return "1.34.0"
 }

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/go.mod
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/jackc/pgx/v4 v4.18.3
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.34.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -21,7 +21,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgtype v1.14.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/test/go.mod
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/test/go.mod
@@ -5,8 +5,8 @@ go 1.25.5
 require (
 	github.com/moby/moby/api v1.55.0
 	github.com/ory/dockertest/v4 v4.0.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.33.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.34.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
@@ -41,7 +41,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect

--- a/instrumentation/github.com/jackc/pgx/v5/splunkpgx/go.mod
+++ b/instrumentation/github.com/jackc/pgx/v5/splunkpgx/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/jackc/pgx/v5 v5.10.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.34.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -17,7 +17,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect

--- a/instrumentation/github.com/jackc/pgx/v5/splunkpgx/test/go.mod
+++ b/instrumentation/github.com/jackc/pgx/v5/splunkpgx/test/go.mod
@@ -5,8 +5,8 @@ go 1.25.5
 require (
 	github.com/moby/moby/api v1.55.0
 	github.com/ory/dockertest/v4 v4.0.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.33.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.34.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
@@ -35,7 +35,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect

--- a/instrumentation/github.com/jinzhu/gorm/splunkgorm/go.mod
+++ b/instrumentation/github.com/jinzhu/gorm/splunkgorm/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/jinzhu/gorm v1.9.16
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.34.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -15,7 +15,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect

--- a/instrumentation/github.com/jmoiron/sqlx/splunksqlx/go.mod
+++ b/instrumentation/github.com/jmoiron/sqlx/splunksqlx/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/jmoiron/sqlx v1.4.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.34.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect

--- a/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test/go.mod
+++ b/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0
 	go.opentelemetry.io/otel v1.45.0

--- a/instrumentation/github.com/lib/pq/splunkpq/go.mod
+++ b/instrumentation/github.com/lib/pq/splunkpq/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/lib/pq v1.12.3
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.34.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect

--- a/instrumentation/github.com/lib/pq/splunkpq/test/go.mod
+++ b/instrumentation/github.com/lib/pq/splunkpq/test/go.mod
@@ -11,8 +11,8 @@ replace (
 require (
 	github.com/moby/moby/api v1.55.0
 	github.com/ory/dockertest/v4 v4.0.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.33.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.34.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
@@ -38,7 +38,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect

--- a/instrumentation/github.com/miekg/dns/splunkdns/go.mod
+++ b/instrumentation/github.com/miekg/dns/splunkdns/go.mod
@@ -6,7 +6,7 @@ go 1.25.0
 
 require (
 	github.com/miekg/dns v1.1.72
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
 )

--- a/instrumentation/github.com/miekg/dns/splunkdns/test/go.mod
+++ b/instrumentation/github.com/miekg/dns/splunkdns/test/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/miekg/dns v1.1.72
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
@@ -18,7 +18,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	golang.org/x/mod v0.38.0 // indirect

--- a/instrumentation/github.com/miekg/dns/splunkdns/version.go
+++ b/instrumentation/github.com/miekg/dns/splunkdns/version.go
@@ -16,5 +16,5 @@ package splunkdns
 
 // Version returns the version of splunkdns.
 func Version() string {
-	return "1.33.0"
+	return "1.34.0"
 }

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/go.mod
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/go.mod
@@ -5,7 +5,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/gole
 go 1.25.0
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0
 	github.com/stretchr/testify v1.11.1
 	github.com/syndtr/goleveldb v1.0.0
 	go.opentelemetry.io/otel v1.45.0

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/go.mod
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/gole
 go 1.25.0
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb v1.34.0
 	github.com/stretchr/testify v1.11.1
 	github.com/syndtr/goleveldb v1.0.0
 	go.opentelemetry.io/otel v1.45.0
@@ -19,7 +19,7 @@ require (
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/version.go
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/version.go
@@ -16,5 +16,5 @@ package splunkleveldb
 
 // Version returns the version of splunkleveldb.
 func Version() string {
-	return "1.33.0"
+	return "1.34.0"
 }

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/go.mod
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/go.mod
@@ -5,7 +5,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/bun
 go 1.25.0
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/buntdb v1.3.2
 	go.opentelemetry.io/otel v1.45.0

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/go.mod
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/bun
 go 1.25.0
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb v1.34.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/buntdb v1.3.2
 	go.opentelemetry.io/otel v1.45.0
@@ -18,7 +18,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	github.com/tidwall/btree v1.8.1 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/grect v0.1.4 // indirect

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/version.go
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/version.go
@@ -16,5 +16,5 @@ package splunkbuntdb
 
 // Version returns the version of splunkbuntdb.
 func Version() string {
-	return "1.33.0"
+	return "1.34.0"
 }

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/go.mod
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/go.mod
@@ -6,7 +6,7 @@ go 1.25.0
 
 require (
 	github.com/olivere/elastic/v7 v7.0.32
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/go.mod
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/moby/moby/api v1.55.0
 	github.com/olivere/elastic/v7 v7.0.32
 	github.com/ory/dockertest/v4 v4.0.0
-	github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
@@ -35,7 +35,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/version.go
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/version.go
@@ -16,5 +16,5 @@ package splunkelastic
 
 // Version returns the version of splunkelastic.
 func Version() string {
-	return "1.33.0"
+	return "1.34.0"
 }

--- a/instrumentation/k8s.io/client-go/splunkclient-go/go.mod
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/go.mod
@@ -5,7 +5,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splun
 go 1.25.0
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/go.mod
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splun
 go 1.25.0
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go v1.33.0
+	github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
@@ -17,7 +17,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.33.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	golang.org/x/net v0.57.0 // indirect

--- a/instrumentation/k8s.io/client-go/splunkclient-go/version.go
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/version.go
@@ -16,5 +16,5 @@ package splunkclientgo
 
 // Version returns the version of splunkclientgo.
 func Version() string {
-	return "1.33.0"
+	return "1.34.0"
 }

--- a/version.go
+++ b/version.go
@@ -20,5 +20,5 @@ package splunkotel // import "github.com/signalfx/splunk-otel-go"
 
 // Version is the current release version of splunk-otel-go in use.
 func Version() string {
-	return "1.33.0"
+	return "1.34.0"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 module-sets:
   stable-v1:
-    version: v1.33.0
+    version: v1.34.0
     modules:
       - github.com/signalfx/splunk-otel-go
       - github.com/signalfx/splunk-otel-go/distro


### PR DESCRIPTION
## Summary

- prepare every stable module for version 1.34.0
- update internal module references and generated version functions
- document the OpenTelemetry Go 1.45.0 and OpenTelemetry Go Contrib 1.45.0 release families
- refresh the README badge and changelog comparison links

## Why

This publishes the dependency updates merged since v1.33.0 as the next Splunk Distribution of OpenTelemetry Go release.

## User impact

Consumers of v1.34.0 will receive the OpenTelemetry Go 1.45.0 dependency family, the matching Contrib 1.45.0 family, and the dependency maintenance accumulated since v1.33.0.

## Validation

- `multimod verify`
- `./goyek.sh test`
