### PR TITLE
build: reject misplaced goyek task arguments

### DIFF
--- a/build/main.go
+++ b/build/main.go
@@ -16,7 +16,10 @@
 package main
 
 import (
+	"errors"
 	"flag"
+	"fmt"
+	"io"
 	"os"
 
 	"github.com/goyek/goyek/v3"
@@ -25,6 +28,7 @@ import (
 
 const (
 	dirBuild          = "build"
+	exitCodeInvalid   = 2
 	repoPackagePrefix = "github.com/signalfx/splunk-otel-go"
 )
 
@@ -35,5 +39,57 @@ func main() {
 		panic(err)
 	}
 	goyek.SetDefault(all)
+	if err := validateArgs(flag.CommandLine, os.Args[1:]); err != nil && !errors.Is(err, flag.ErrHelp) {
+		fmt.Fprintln(goyek.Output(), err)
+		os.Exit(exitCodeInvalid)
+	}
 	boot.Main()
+}
+
+type boolFlag interface {
+	IsBoolFlag() bool
+}
+
+type validationFlagValue struct {
+	isBool bool
+}
+
+func (v *validationFlagValue) IsBoolFlag() bool {
+	return v.isBool
+}
+
+func (*validationFlagValue) Set(string) error {
+	return nil
+}
+
+func (*validationFlagValue) String() string {
+	return ""
+}
+
+func validateArgs(flags *flag.FlagSet, args []string) error {
+	_, flagArgs := goyek.SplitTasks(args)
+	// Only positional arguments after an explicit separator are intentional.
+	for i, arg := range flagArgs {
+		if arg == "--" {
+			flagArgs = flagArgs[:i]
+			break
+		}
+	}
+
+	validationFlags := flag.NewFlagSet(flags.Name(), flag.ContinueOnError)
+	validationFlags.SetOutput(io.Discard)
+	// Parse no-op copies so validation follows each flag's argument arity
+	// without applying flag values before boot.Main parses them.
+	flags.VisitAll(func(f *flag.Flag) {
+		bf, ok := f.Value.(boolFlag)
+		validationFlags.Var(&validationFlagValue{isBool: ok && bf.IsBoolFlag()}, f.Name, f.Usage)
+	})
+
+	if err := validationFlags.Parse(flagArgs); err != nil {
+		return err
+	}
+	if validationFlags.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %v", validationFlags.Args())
+	}
+	return nil
 }

--- a/build/main_test.go
+++ b/build/main_test.go
@@ -1,0 +1,143 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"testing"
+)
+
+const (
+	argSeparator    = "--"
+	argument        = "argument"
+	errUnexpectedCI = "unexpected arguments: [ci]"
+	flagMessage     = "-msg"
+	flagVerbose     = "-v"
+	taskCI          = "ci"
+	taskRelease     = "release"
+)
+
+func TestValidateArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "no arguments",
+		},
+		{
+			name: "tasks only",
+			args: []string{taskCI},
+		},
+		{
+			name: "task before flag",
+			args: []string{taskCI, flagVerbose},
+		},
+		{
+			name: "task before inline boolean flag",
+			args: []string{taskCI, "-v=false"},
+		},
+		{
+			name:    "task after flag",
+			args:    []string{flagVerbose, taskCI},
+			wantErr: errUnexpectedCI,
+		},
+		{
+			name:    "task after inline boolean flag",
+			args:    []string{"-v=false", taskCI},
+			wantErr: errUnexpectedCI,
+		},
+		{
+			name:    "argument after boolean flag",
+			args:    []string{taskCI, flagVerbose, "false"},
+			wantErr: "unexpected arguments: [false]",
+		},
+		{
+			name:    "tasks after flag",
+			args:    []string{flagVerbose, "all", "diff"},
+			wantErr: "unexpected arguments: [all diff]",
+		},
+		{
+			name:    "task between flag and separator",
+			args:    []string{flagVerbose, taskCI, argSeparator, argument},
+			wantErr: errUnexpectedCI,
+		},
+		{
+			name: "arguments after separator",
+			args: []string{taskCI, flagVerbose, argSeparator, argument, "-other"},
+		},
+		{
+			name: "arguments after separator without tasks",
+			args: []string{argSeparator, "all", "diff"},
+		},
+		{
+			name: "separate flag value",
+			args: []string{taskRelease, flagMessage, "value", argSeparator, argument},
+		},
+		{
+			name: "separate flag value starting with dash",
+			args: []string{taskRelease, flagMessage, "-value"},
+		},
+		{
+			name:    "separator cannot be a flag value",
+			args:    []string{taskRelease, flagMessage, argSeparator, argument},
+			wantErr: "flag needs an argument: -msg",
+		},
+		{
+			name: "separator as inline flag value",
+			args: []string{taskRelease, "-msg=--", argSeparator, argument},
+		},
+		{
+			name:    "unknown flag",
+			args:    []string{taskCI, "-unknown"},
+			wantErr: "flag provided but not defined: -unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := flag.NewFlagSet("build", flag.ContinueOnError)
+			verbose := flags.Bool("v", false, "verbose output")
+			message := flags.String("msg", "default", "message")
+
+			err := validateArgs(flags, tt.args)
+			if gotErr := errorString(err); gotErr != tt.wantErr {
+				t.Errorf("validateArgs(%v) error = %q, want %q", tt.args, gotErr, tt.wantErr)
+			}
+			if *verbose {
+				t.Errorf("validateArgs(%v) modified -v", tt.args)
+			}
+			if *message != "default" {
+				t.Errorf("validateArgs(%v) modified -msg to %q", tt.args, *message)
+			}
+		})
+	}
+}
+
+func TestValidateArgsHelp(t *testing.T) {
+	flags := flag.NewFlagSet("build", flag.ContinueOnError)
+	if err := validateArgs(flags, []string{"-h"}); !errors.Is(err, flag.ErrHelp) {
+		t.Errorf("validateArgs([-h]) error = %v, want flag.ErrHelp", err)
+	}
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}


### PR DESCRIPTION
## Why

The build program uses goyek/x v0.4.0. With task names placed after flags (for example, `./goyek.sh -v ci`), flag parsing silently leaves `ci` as a positional argument, no explicit task is selected, and the default `all` task runs without the final `diff` check. Existing CI invocations are ordered correctly, but malformed or future reordered invocations can still pass while skipping requested tasks.

## What

- Validate task/flag ordering before calling `boot.Main`.
- Parse a no-op copy of registered flags so validation preserves flag arity without applying values twice.
- Preserve intentional arguments after an explicit `--`.
- Add regression coverage for valid ordering, misplaced tasks, flag values, separator handling, help, and unknown flags.

This is a consumer-local guard while [goyek/x#316](https://github.com/goyek/x/pull/316) is pending; pinning its current head would import 59 unrelated unreleased commits.

## Testing

- Go 1.26 and 1.27 race tests for the build module
- Go 1.25 root tests
- `go vet`
- `golangci-lint`
- `go mod tidy -diff`
- Valid and invalid CLI dry runs
